### PR TITLE
feat(issue 285): Add provenance support

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ If `provenance: true` is added to your `release.yml`'s **inputs**, NPM will [gen
 NPM has some internal [requirements](https://docs.npmjs.com/generating-provenance-statements#prerequisites) for generating provenance. Unfortunately as of May 2023, not all are documented by NPM; some key requirements are:
 
 - `id-token: write` must be added to your `release.yml`'s **permissions**
-- NPM must on version 9.5.0 or greater (this will be met if our recommended `runs-on: ubuntu-latest` is used)
+- NPM must be on version 9.5.0 or greater (this will be met if our recommended `runs-on: ubuntu-latest` is used)
 - NPM has some undocumented internal requirements on `package.json` completeness. For example, the [repository field](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repository) is required, and some NPM versions may require its `"url"` property to match the format `"git+https://github.com/user/repo"`.
 
 If any requirements are not met, the release will be aborted before publishing the new version, and an appropriate error will be shown in the actions report. The release commit can be reverted and the action re-tried after fixing the issue highlighted in the logged error.

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ NPM will [generate a provenance statement](https://docs.npmjs.com/generating-pro
    - Add `provenance: true` to your list of **inputs**
    - Add `id-token: write` to your list of **permissions**
  - Ensure your CI runner uses NPM >= 9.5.0 (should be the default if Node >= 18)
- - Ensure your `package.json` is complete and correct. NPM will cancel the release with specific errors if it finds a problem.Requirements may change in future NPM releases but include things like a `"repository"` field with `"url"` property matching the format `"git+https://github.com/user/repo"`.
+ - Ensure your `package.json` is complete and correct. NPM will cancel the release with specific errors if it finds a problem. Requirements may change in future NPM releases but include things like a `"repository"` field with `"url"` property matching the format `"git+https://github.com/user/repo"`.
 
 If `provenance: true` is in your YML inputs and any condition isn't met, the release will cancel with an error. 
 
@@ -254,7 +254,7 @@ If you run a release without `provenance: true` when a previous release had prov
 | `version-prefix`       | No       | A prefix to apply to the version number, which reflects in the tag and GitHub release names. <br /> (_Default: 'v'_)                                                                                                                                                                                                                                         |
 | `prerelease-prefix`       | No       | A prefix to apply to the prerelease version number.                                                                                                                                                                                                                                         |
 | `base-tag`       | No       | Choose a specific tag release for your release notes. This input allows you to specify a base release (for example, v1.0.0) and will include all changes made in releases between the base release and the latest release. This input is only used for generating release notes and has no functional implications on the rest of the workflow.                                                                                                                                                                                                                                         |
-| `provenance`| No    | Set as true to have NPM [generate a provenance statement](https://docs.npmjs.com/generating-provenance-statements). See [Provenance section above](#provenance) for requirements. Also <br /> (_Default: `false`_)                                                                  |
+| `provenance`| No    | Set as true to have NPM [generate a provenance statement](https://docs.npmjs.com/generating-provenance-statements). See [Provenance section above](#provenance) for requirements.<br /> (_Default: `false`_)                                                                  |
 
 
 ## Motivation

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This action allows you to automate the release process of your npm modules, apps
   - [Example](#example-1)
 - [How to add a build step to your workflow](#how-to-add-a-build-step-to-your-workflow)
 - [Prerelease support](#prerelease-support)
+- [Provenance](#provenance)
 - [Inputs](#inputs)
 - [Motivation](#motivation)
 - [Playground / Testing](#playground--testing)
@@ -217,6 +218,20 @@ Generally, if you want to release a prerelease of a repository, and it is an NPM
 
 Please note that in case of a prerelease the `sync-semver-tags` input will be treated as `false`, even if it's set to `true`. This because we don't want to update the main version tags to the latest prerelease commit but only to the latest official release.
 
+## Provenance
+
+NPM will [generate a provenance statement](https://docs.npmjs.com/generating-provenance-statements) for your releases if the following conditions are met:
+
+ - In the `.yml` file that configures your release action:
+   - Add `provenance: true` to your list of **inputs**
+   - Add `id-token: write` to your list of **permissions**
+ - Ensure your CI runner uses NPM >= 9.5.0 (should be the default if Node >= 18)
+ - Ensure your `package.json` is complete and correct. will cancel the release with specific errors if it finds a problem. Requirements may change in future NPM releases but include things like a `"repository"` field with `"url"` property matching the format `"git+https://github.com/user/repo"`.
+
+If `provenance: true` is in your YML inputs and any condition isn't met, the release will cancel with an error. 
+
+If you run a release without `provenance: true` when a previous release had provenance, the provenance banner on your package's NPM landing page will be removed but the banner will remain on the subpage for the previous release.
+
 ## Inputs
 
 | Input          | Required | Description                                                                                                                                                                                |
@@ -239,6 +254,8 @@ Please note that in case of a prerelease the `sync-semver-tags` input will be tr
 | `version-prefix`       | No       | A prefix to apply to the version number, which reflects in the tag and GitHub release names. <br /> (_Default: 'v'_)                                                                                                                                                                                                                                         |
 | `prerelease-prefix`       | No       | A prefix to apply to the prerelease version number.                                                                                                                                                                                                                                         |
 | `base-tag`       | No       | Choose a specific tag release for your release notes. This input allows you to specify a base release (for example, v1.0.0) and will include all changes made in releases between the base release and the latest release. This input is only used for generating release notes and has no functional implications on the rest of the workflow.                                                                                                                                                                                                                                         |
+| `provenance`| No    | Set as true to have NPM [generate a provenance statement](https://docs.npmjs.com/generating-provenance-statements). See [Provenance section above](#Provenance) for requirements. Also <br /> (_Default: `false`_)                                                                  |
+
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ NPM has some internal [requirements](https://docs.npmjs.com/generating-provenanc
 
 If any requirements are not met, the release will be aborted before publishing the new version, and an appropriate error will be shown in the actions report. The release commit can be reverted and the action re-tried after fixing the issue highlighted in the logged error.
 
-The above [example yml action](example) includes support for Provenance. To add provenance support to an existing action, add these two lines:
+The above [example yml action](#example) includes support for Provenance. To add provenance support to an existing action, add these two lines:
 
 ```yml
 jobs:

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ NPM will [generate a provenance statement](https://docs.npmjs.com/generating-pro
    - Add `provenance: true` to your list of **inputs**
    - Add `id-token: write` to your list of **permissions**
  - Ensure your CI runner uses NPM >= 9.5.0 (should be the default if Node >= 18)
- - Ensure your `package.json` is complete and correct. will cancel the release with specific errors if it finds a problem. Requirements may change in future NPM releases but include things like a `"repository"` field with `"url"` property matching the format `"git+https://github.com/user/repo"`.
+ - Ensure your `package.json` is complete and correct. NPM will cancel the release with specific errors if it finds a problem.Requirements may change in future NPM releases but include things like a `"repository"` field with `"url"` property matching the format `"git+https://github.com/user/repo"`.
 
 If `provenance: true` is in your YML inputs and any condition isn't met, the release will cancel with an error. 
 
@@ -254,7 +254,7 @@ If you run a release without `provenance: true` when a previous release had prov
 | `version-prefix`       | No       | A prefix to apply to the version number, which reflects in the tag and GitHub release names. <br /> (_Default: 'v'_)                                                                                                                                                                                                                                         |
 | `prerelease-prefix`       | No       | A prefix to apply to the prerelease version number.                                                                                                                                                                                                                                         |
 | `base-tag`       | No       | Choose a specific tag release for your release notes. This input allows you to specify a base release (for example, v1.0.0) and will include all changes made in releases between the base release and the latest release. This input is only used for generating release notes and has no functional implications on the rest of the workflow.                                                                                                                                                                                                                                         |
-| `provenance`| No    | Set as true to have NPM [generate a provenance statement](https://docs.npmjs.com/generating-provenance-statements). See [Provenance section above](#Provenance) for requirements. Also <br /> (_Default: `false`_)                                                                  |
+| `provenance`| No    | Set as true to have NPM [generate a provenance statement](https://docs.npmjs.com/generating-provenance-statements). See [Provenance section above](#provenance) for requirements. Also <br /> (_Default: `false`_)                                                                  |
 
 
 ## Motivation

--- a/action.yml
+++ b/action.yml
@@ -75,6 +75,11 @@ inputs:
   base-tag:
     description: 'This input allows you to specify a base release and will include all changes made in releases between the base release and the latest release'
     required: false
+  provenance:
+    description: 'If true, NPM >9.5 will display a "provenance" badge (https://github.blog/2023-04-19-introducing-npm-package-provenance/). The default setting is "true".'
+    required: false
+    type: boolean
+    default: 'true'
 
 runs:
   using: 'composite'

--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ inputs:
     description: 'This input allows you to specify a base release and will include all changes made in releases between the base release and the latest release'
     required: false
   provenance:
-    description: 'If true, NPM >9.5 will attempt to generate and display a "provenance" badge (https://github.blog/2023-04-19-introducing-npm-package-provenance/).'
+    description: 'If true, NPM >9.5 will attempt to generate and display a "provenance" badge. See https://docs.npmjs.com/generating-provenance-statements'
     required: false
     type: boolean
     default: 'false'

--- a/action.yml
+++ b/action.yml
@@ -76,10 +76,10 @@ inputs:
     description: 'This input allows you to specify a base release and will include all changes made in releases between the base release and the latest release'
     required: false
   provenance:
-    description: 'If true, NPM >9.5 will display a "provenance" badge (https://github.blog/2023-04-19-introducing-npm-package-provenance/). The default setting is "true".'
+    description: 'If true, NPM >9.5 will attempt to generate and display a "provenance" badge (https://github.blog/2023-04-19-introducing-npm-package-provenance/).'
     required: false
     type: boolean
-    default: 'true'
+    default: 'false'
 
 runs:
   using: 'composite'

--- a/dist/index.js
+++ b/dist/index.js
@@ -79838,7 +79838,6 @@ async function publishToNpm({
     `//registry.npmjs.org/:_authToken=${npmToken}`,
   ])
 
-  const options = {}
   const flags = ['--tag', npmTag]
   if (provenance) {
     flags.push('--provenance')
@@ -79851,9 +79850,9 @@ async function publishToNpm({
         '-s',
         `${opticUrl}${opticToken}`,
       ])
-      await execWithOutput('npm', ['publish', '--otp', otp, ...flags], options)
+      await execWithOutput('npm', ['publish', '--otp', otp, ...flags])
     } else {
-      await execWithOutput('npm', ['publish', ...flags], options)
+      await execWithOutput('npm', ['publish', ...flags])
     }
   }
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -79219,6 +79219,7 @@ const { publishToNpm } = __nccwpck_require__(1433)
 const { notifyIssues } = __nccwpck_require__(8361)
 const { logError, logInfo, logWarning } = __nccwpck_require__(653)
 const { execWithOutput } = __nccwpck_require__(8632)
+const { checkProvenanceViability } = __nccwpck_require__(5560)
 
 module.exports = async function ({ github, context, inputs }) {
   logInfo('** Starting Release **')
@@ -79304,6 +79305,9 @@ module.exports = async function ({ github, context, inputs }) {
     const opticToken = inputs['optic-token']
     const npmToken = inputs['npm-token']
     const provenance = inputs['provenance']
+
+    // Fail fast if user wants provenance but their setup can't deliver
+    if (provenance) await checkProvenanceViability()
 
     if (npmToken) {
       await publishToNpm({
@@ -79956,7 +79960,9 @@ module.exports = {
 
 
 const github = __nccwpck_require__(5438)
+const semver = __nccwpck_require__(1383)
 const { logInfo, logError } = __nccwpck_require__(653)
+const { execWithOutput } = __nccwpck_require__(8632)
 
 async function fetchLatestRelease(token) {
   try {
@@ -80038,10 +80044,49 @@ async function fetchReleaseByTag(token, tag) {
   }
 }
 
+/**
+ * Fail fast with a meaningful error if NPM Provenance will fail.
+ *
+ * @see https://docs.npmjs.com/generating-provenance-statements
+ */
+async function checkProvenanceViability() {
+  const npmVersion = await execWithOutput('npm', ['-v'])
+
+  const validNpmVersion = '>=9.5.0'
+  const correctNpmErrorVersion = '>=9.6.1'
+
+  // Abort if the user specified they want NPM provenance, but their CI's NPM version doesn't support it.
+  // If we continued, the release will go ahead with no warnings, and no provenance will be generated.
+  if (!semver.satisfies(npmVersion, validNpmVersion)) {
+    throw new Error(
+      `Provenance requires NPM ${validNpmVersion}, but this action is using v${npmVersion}.
+Either remove provenance from your release action's inputs, or update your release CI's NPM version.`
+    )
+  }
+
+  // Abort with a meaningful error if the user will get a misleading error message from NPM.
+  // As of April 2023 this affects anyone whose CI is set to use Node 18 (defaults to NPM 9.5.1).
+  if (
+    !process.env.ACTIONS_ID_TOKEN_REQUEST_URL &&
+    // In NPM versions after https://github.com/npm/cli/pull/6226 landed, we can let NPM handle it.
+    !semver.satisfies(correctNpmErrorVersion)
+  ) {
+    throw new Error(
+      // Throw the same error message that updated versions of NPM will throw.
+      `Provenance generation in GitHub Actions requires "write" access to the "id-token" permission`
+    )
+  }
+
+  // There are various other provenance requirements, such as specific package.json properties, but these
+  // may change with future versions, and do fail with meaningful errors, so we can let NPM handle those.
+  return true
+}
+
 module.exports = {
   fetchLatestRelease,
   generateReleaseNotes,
   fetchReleaseByTag,
+  checkProvenanceViability,
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -79303,7 +79303,7 @@ module.exports = async function ({ github, context, inputs }) {
   try {
     const opticToken = inputs['optic-token']
     const npmToken = inputs['npm-token']
-    const provenance = inputs['provenance'] ?? true
+    const provenance = inputs['provenance']
 
     if (npmToken) {
       await publishToNpm({

--- a/dist/index.js
+++ b/dist/index.js
@@ -79304,7 +79304,7 @@ module.exports = async function ({ github, context, inputs }) {
   try {
     const opticToken = inputs['optic-token']
     const npmToken = inputs['npm-token']
-    const provenance = inputs['provenance']
+    const provenance = /true/i.test(inputs['provenance'])
 
     // Fail fast if user wants provenance but their setup can't deliver
     if (provenance) await checkProvenanceViability()

--- a/dist/index.js
+++ b/dist/index.js
@@ -79576,14 +79576,18 @@ const { exec } = __nccwpck_require__(1514)
  * @param {{cwd?: string}} options
  * @returns Promise<string>
  */
-async function execWithOutput(cmd, args, { cwd, ...options } = {}) {
+async function execWithOutput(
+  cmd,
+  args,
+  { cwd, silent = false, ...options } = {}
+) {
   let output = ''
   let errorOutput = ''
 
   const stdoutDecoder = new StringDecoder('utf8')
   const stderrDecoder = new StringDecoder('utf8')
 
-  options.silent = false
+  options.silent = silent
 
   /* istanbul ignore else */
   if (cwd !== '') {

--- a/dist/index.js
+++ b/dist/index.js
@@ -79851,7 +79851,7 @@ function checkProvenanceViability(npmVersion) {
  * Split out as its own export so it can be easily mocked in tests.
  */
 async function getNpmVersion() {
-  return await execWithOutput('npm', ['-v'])
+  return execWithOutput('npm', ['-v'])
 }
 
 module.exports = {

--- a/src/release.js
+++ b/src/release.js
@@ -96,7 +96,7 @@ module.exports = async function ({ github, context, inputs }) {
   try {
     const opticToken = inputs['optic-token']
     const npmToken = inputs['npm-token']
-    const provenance = inputs['provenance']
+    const provenance = /true/i.test(inputs['provenance'])
 
     // Fail fast if user wants provenance but their setup can't deliver
     if (provenance) await checkProvenanceViability()

--- a/src/release.js
+++ b/src/release.js
@@ -95,7 +95,7 @@ module.exports = async function ({ github, context, inputs }) {
   try {
     const opticToken = inputs['optic-token']
     const npmToken = inputs['npm-token']
-    const provenance = inputs['provenance'] ?? true
+    const provenance = inputs['provenance']
 
     if (npmToken) {
       await publishToNpm({

--- a/src/release.js
+++ b/src/release.js
@@ -11,6 +11,7 @@ const { publishToNpm } = require('./utils/publishToNpm')
 const { notifyIssues } = require('./utils/notifyIssues')
 const { logError, logInfo, logWarning } = require('./log')
 const { execWithOutput } = require('./utils/execWithOutput')
+const { checkProvenanceViability } = require('./utils/releases')
 
 module.exports = async function ({ github, context, inputs }) {
   logInfo('** Starting Release **')
@@ -96,6 +97,9 @@ module.exports = async function ({ github, context, inputs }) {
     const opticToken = inputs['optic-token']
     const npmToken = inputs['npm-token']
     const provenance = inputs['provenance']
+
+    // Fail fast if user wants provenance but their setup can't deliver
+    if (provenance) await checkProvenanceViability()
 
     if (npmToken) {
       await publishToNpm({

--- a/src/release.js
+++ b/src/release.js
@@ -95,9 +95,17 @@ module.exports = async function ({ github, context, inputs }) {
   try {
     const opticToken = inputs['optic-token']
     const npmToken = inputs['npm-token']
+    const provenance = inputs['provenance'] ?? true
 
     if (npmToken) {
-      await publishToNpm({ npmToken, opticToken, opticUrl, npmTag, version })
+      await publishToNpm({
+        npmToken,
+        opticToken,
+        opticUrl,
+        npmTag,
+        version,
+        provenance,
+      })
     } else {
       logWarning('missing npm-token')
     }

--- a/src/release.js
+++ b/src/release.js
@@ -11,7 +11,10 @@ const { publishToNpm } = require('./utils/publishToNpm')
 const { notifyIssues } = require('./utils/notifyIssues')
 const { logError, logInfo, logWarning } = require('./log')
 const { execWithOutput } = require('./utils/execWithOutput')
-const { checkProvenanceViability } = require('./utils/releases')
+const {
+  checkProvenanceViability,
+  getNpmVersion,
+} = require('./utils/provenance')
 
 module.exports = async function ({ github, context, inputs }) {
   logInfo('** Starting Release **')
@@ -98,8 +101,11 @@ module.exports = async function ({ github, context, inputs }) {
     const npmToken = inputs['npm-token']
     const provenance = /true/i.test(inputs['provenance'])
 
-    // Fail fast if user wants provenance but their setup can't deliver
-    if (provenance) await checkProvenanceViability()
+    // Fail fast with meaningful error if user wants provenance but their setup won't deliver
+    if (provenance) {
+      const npmVersion = await getNpmVersion()
+      checkProvenanceViability(npmVersion)
+    }
 
     if (npmToken) {
       await publishToNpm({

--- a/src/utils/execWithOutput.js
+++ b/src/utils/execWithOutput.js
@@ -11,16 +11,14 @@ const { exec } = require('@actions/exec')
  * @param {{cwd?: string}} options
  * @returns Promise<string>
  */
-async function execWithOutput(cmd, args, { cwd } = {}) {
+async function execWithOutput(cmd, args, { cwd, ...options } = {}) {
   let output = ''
   let errorOutput = ''
 
   const stdoutDecoder = new StringDecoder('utf8')
   const stderrDecoder = new StringDecoder('utf8')
 
-  const options = {
-    silent: false,
-  }
+  options.silent = false
 
   /* istanbul ignore else */
   if (cwd !== '') {

--- a/src/utils/execWithOutput.js
+++ b/src/utils/execWithOutput.js
@@ -11,14 +11,18 @@ const { exec } = require('@actions/exec')
  * @param {{cwd?: string}} options
  * @returns Promise<string>
  */
-async function execWithOutput(cmd, args, { cwd, ...options } = {}) {
+async function execWithOutput(
+  cmd,
+  args,
+  { cwd, silent = false, ...options } = {}
+) {
   let output = ''
   let errorOutput = ''
 
   const stdoutDecoder = new StringDecoder('utf8')
   const stderrDecoder = new StringDecoder('utf8')
 
-  options.silent = false
+  options.silent = silent
 
   /* istanbul ignore else */
   if (cwd !== '') {

--- a/src/utils/provenance.js
+++ b/src/utils/provenance.js
@@ -1,0 +1,70 @@
+'use strict'
+const semver = require('semver')
+const { execWithOutput } = require('./execWithOutput')
+
+/**
+ * Abort if the user specified they want NPM provenance, but their CI's NPM version doesn't support it.
+ * If we continued, the release will go ahead with no warnings, and no provenance will be generated.
+ */
+function checkIsSupported(npmVersion) {
+  const validNpmVersion = '>=9.5.0'
+
+  if (!semver.satisfies(npmVersion, validNpmVersion)) {
+    throw new Error(
+      `Provenance requires NPM ${validNpmVersion}, but this action is using v${npmVersion}.
+Either remove provenance from your release action's inputs, or update your release CI's NPM version.`
+    )
+  }
+}
+
+/**
+ * Abort with a meaningful error if the user would get a misleading error message from NPM
+ * due to an NPM bug that existed between 9.5.0 and 9.6.1.
+ * As of April 2023, this would affect anyone whose CI is set to Node 18 (which defaults to NPM 9.5.1).
+ */
+function checkPermissions(npmVersion) {
+  // Bug was fixed in this NPM version - see https://github.com/npm/cli/pull/6226
+  const correctNpmErrorVersion = '>=9.6.1'
+
+  if (
+    // Same test condition as in fixed versions of NPM
+    !process.env.ACTIONS_ID_TOKEN_REQUEST_URL &&
+    // Let NPM handle this itself after their bug was fixed, so we're not brittle against future changes
+    !semver.satisfies(npmVersion, correctNpmErrorVersion)
+  ) {
+    throw new Error(
+      // Same error message as in fixed versions of NPM
+      'Provenance generation in GitHub Actions requires "write" access to the "id-token" permission'
+    )
+  }
+}
+
+/**
+ * Fail fast and throw a meaningful error if NPM Provenance will fail silently or misleadingly.
+ *
+ * @see https://docs.npmjs.com/generating-provenance-statements
+ *
+ * @param {string} npmVersion
+ */
+function checkProvenanceViability(npmVersion) {
+  if (!npmVersion) throw new Error('Current npm version not provided')
+  checkIsSupported(npmVersion)
+  checkPermissions(npmVersion)
+  // There are various other provenance requirements, such as specific package.json properties, but these
+  // may change in future NPM versions, and do fail with meaningful errors, so we let NPM handle those.
+}
+
+/**
+ * Gets npm version via `npm -v` on the command line.
+ * Split out as its own export so it can be easily mocked in tests.
+ */
+async function getNpmVersion() {
+  return await execWithOutput('npm', ['-v'])
+}
+
+module.exports = {
+  checkProvenanceViability,
+  getNpmVersion,
+  checkIsSupported,
+  checkPermissions,
+}

--- a/src/utils/provenance.js
+++ b/src/utils/provenance.js
@@ -59,7 +59,7 @@ function checkProvenanceViability(npmVersion) {
  * Split out as its own export so it can be easily mocked in tests.
  */
 async function getNpmVersion() {
-  return await execWithOutput('npm', ['-v'])
+  return execWithOutput('npm', ['-v'])
 }
 
 module.exports = {

--- a/src/utils/publishToNpm.js
+++ b/src/utils/publishToNpm.js
@@ -48,12 +48,19 @@ async function publishToNpm({
   opticUrl,
   npmTag,
   version,
+  provenance,
 }) {
   await execWithOutput('npm', [
     'config',
     'set',
     `//registry.npmjs.org/:_authToken=${npmToken}`,
   ])
+
+  const options = {}
+  const flags = ['--tag', npmTag]
+  if (provenance) {
+    flags.push('--provenance')
+  }
 
   if (await allowNpmPublish(version)) {
     await execWithOutput('npm', ['pack', '--dry-run'])
@@ -62,9 +69,9 @@ async function publishToNpm({
         '-s',
         `${opticUrl}${opticToken}`,
       ])
-      await execWithOutput('npm', ['publish', '--otp', otp, '--tag', npmTag])
+      await execWithOutput('npm', ['publish', '--otp', otp, ...flags], options)
     } else {
-      await execWithOutput('npm', ['publish', '--tag', npmTag])
+      await execWithOutput('npm', ['publish', ...flags], options)
     }
   }
 }

--- a/src/utils/publishToNpm.js
+++ b/src/utils/publishToNpm.js
@@ -56,7 +56,6 @@ async function publishToNpm({
     `//registry.npmjs.org/:_authToken=${npmToken}`,
   ])
 
-  const options = {}
   const flags = ['--tag', npmTag]
   if (provenance) {
     flags.push('--provenance')
@@ -69,9 +68,9 @@ async function publishToNpm({
         '-s',
         `${opticUrl}${opticToken}`,
       ])
-      await execWithOutput('npm', ['publish', '--otp', otp, ...flags], options)
+      await execWithOutput('npm', ['publish', '--otp', otp, ...flags])
     } else {
-      await execWithOutput('npm', ['publish', ...flags], options)
+      await execWithOutput('npm', ['publish', ...flags])
     }
   }
 }

--- a/src/utils/releases.js
+++ b/src/utils/releases.js
@@ -1,9 +1,7 @@
 'use strict'
 
 const github = require('@actions/github')
-const semver = require('semver')
 const { logInfo, logError } = require('../log')
-const { execWithOutput } = require('./execWithOutput')
 
 async function fetchLatestRelease(token) {
   try {
@@ -85,47 +83,8 @@ async function fetchReleaseByTag(token, tag) {
   }
 }
 
-/**
- * Fail fast with a meaningful error if NPM Provenance will fail.
- *
- * @see https://docs.npmjs.com/generating-provenance-statements
- */
-async function checkProvenanceViability() {
-  const npmVersion = await execWithOutput('npm', ['-v'])
-
-  const validNpmVersion = '>=9.5.0'
-  const correctNpmErrorVersion = '>=9.6.1'
-
-  // Abort if the user specified they want NPM provenance, but their CI's NPM version doesn't support it.
-  // If we continued, the release will go ahead with no warnings, and no provenance will be generated.
-  if (!semver.satisfies(npmVersion, validNpmVersion)) {
-    throw new Error(
-      `Provenance requires NPM ${validNpmVersion}, but this action is using v${npmVersion}.
-Either remove provenance from your release action's inputs, or update your release CI's NPM version.`
-    )
-  }
-
-  // Abort with a meaningful error if the user will get a misleading error message from NPM.
-  // As of April 2023 this affects anyone whose CI is set to use Node 18 (defaults to NPM 9.5.1).
-  if (
-    !process.env.ACTIONS_ID_TOKEN_REQUEST_URL &&
-    // In NPM versions after https://github.com/npm/cli/pull/6226 landed, we can let NPM handle it.
-    !semver.satisfies(correctNpmErrorVersion)
-  ) {
-    throw new Error(
-      // Throw the same error message that updated versions of NPM will throw.
-      `Provenance generation in GitHub Actions requires "write" access to the "id-token" permission`
-    )
-  }
-
-  // There are various other provenance requirements, such as specific package.json properties, but these
-  // may change with future versions, and do fail with meaningful errors, so we can let NPM handle those.
-  return true
-}
-
 module.exports = {
   fetchLatestRelease,
   generateReleaseNotes,
   fetchReleaseByTag,
-  checkProvenanceViability,
 }

--- a/src/utils/releases.js
+++ b/src/utils/releases.js
@@ -1,7 +1,9 @@
 'use strict'
 
 const github = require('@actions/github')
+const semver = require('semver')
 const { logInfo, logError } = require('../log')
+const { execWithOutput } = require('./execWithOutput')
 
 async function fetchLatestRelease(token) {
   try {
@@ -83,8 +85,47 @@ async function fetchReleaseByTag(token, tag) {
   }
 }
 
+/**
+ * Fail fast with a meaningful error if NPM Provenance will fail.
+ *
+ * @see https://docs.npmjs.com/generating-provenance-statements
+ */
+async function checkProvenanceViability() {
+  const npmVersion = await execWithOutput('npm', ['-v'])
+
+  const validNpmVersion = '>=9.5.0'
+  const correctNpmErrorVersion = '>=9.6.1'
+
+  // Abort if the user specified they want NPM provenance, but their CI's NPM version doesn't support it.
+  // If we continued, the release will go ahead with no warnings, and no provenance will be generated.
+  if (!semver.satisfies(npmVersion, validNpmVersion)) {
+    throw new Error(
+      `Provenance requires NPM ${validNpmVersion}, but this action is using v${npmVersion}.
+Either remove provenance from your release action's inputs, or update your release CI's NPM version.`
+    )
+  }
+
+  // Abort with a meaningful error if the user will get a misleading error message from NPM.
+  // As of April 2023 this affects anyone whose CI is set to use Node 18 (defaults to NPM 9.5.1).
+  if (
+    !process.env.ACTIONS_ID_TOKEN_REQUEST_URL &&
+    // In NPM versions after https://github.com/npm/cli/pull/6226 landed, we can let NPM handle it.
+    !semver.satisfies(correctNpmErrorVersion)
+  ) {
+    throw new Error(
+      // Throw the same error message that updated versions of NPM will throw.
+      `Provenance generation in GitHub Actions requires "write" access to the "id-token" permission`
+    )
+  }
+
+  // There are various other provenance requirements, such as specific package.json properties, but these
+  // may change with future versions, and do fail with meaningful errors, so we can let NPM handle those.
+  return true
+}
+
 module.exports = {
   fetchLatestRelease,
   generateReleaseNotes,
   fetchReleaseByTag,
+  checkProvenanceViability,
 }

--- a/test/provenance.test.js
+++ b/test/provenance.test.js
@@ -1,0 +1,84 @@
+'use strict'
+
+const tap = require('tap')
+const semver = require('semver')
+const sinon = require('sinon')
+const {
+  checkIsSupported,
+  checkPermissions,
+  checkProvenanceViability,
+  getNpmVersion,
+} = require('../src/utils/provenance')
+
+const MINIMUM_VERSION = '9.5.0'
+
+tap.afterEach(() => {
+  sinon.restore()
+})
+
+tap.test('getNpmVersion can get a real NPM version number', async t => {
+  const npmVersion = await getNpmVersion()
+
+  t.type(npmVersion, 'string')
+
+  // We don't care which version of NPM tests are run on, just that it gets any valid version
+  t.ok(semver.satisfies(npmVersion, '>0.0.1'))
+})
+
+tap.test('checkIsSupported passes on minimum NPM version', async t => {
+  t.doesNotThrow(() => checkIsSupported(MINIMUM_VERSION))
+})
+
+tap.test('checkIsSupported passes on major version after minimum', async t => {
+  t.doesNotThrow(() => checkIsSupported('10.0.0'))
+})
+
+tap.test('checkIsSupported fails on minor version before minimum', async t => {
+  t.throws(
+    () => checkIsSupported('9.4.0'),
+    `Provenance requires NPM ${MINIMUM_VERSION}`
+  )
+})
+
+tap.test('checkIsSupported fails on major version before minimum', async t => {
+  t.throws(
+    () => checkIsSupported('8.0.0'),
+    `Provenance requires NPM ${MINIMUM_VERSION}`
+  )
+})
+
+tap.test('checkPermissions always passes on NPM 9.6.1', async t => {
+  t.doesNotThrow(() => checkIsSupported('9.6.1'))
+})
+
+tap.test(
+  'checkPermissions always passes on next major NPM version',
+  async t => {
+    t.doesNotThrow(() => checkIsSupported('10.0.0'))
+  }
+)
+
+tap.test('checkPermissions fails on minimum version without env', async t => {
+  t.throws(
+    () => checkPermissions(MINIMUM_VERSION),
+    'Provenance generation in GitHub Actions requires "write" access to the "id-token" permission'
+  )
+})
+
+tap.test('checkPermissions passes on minimum version with env', async t => {
+  sinon
+    .stub(process, 'env')
+    .value({ ACTIONS_ID_TOKEN_REQUEST_URL: 'https://example.com' })
+
+  t.doesNotThrow(() => checkIsSupported(MINIMUM_VERSION))
+})
+
+tap.test(
+  'checkProvenanceViability fails fast if NPM version unavailable',
+  async t => {
+    t.throws(
+      () => checkProvenanceViability(),
+      'Current npm version not provided'
+    )
+  }
+)

--- a/test/publishToNpm.test.js
+++ b/test/publishToNpm.test.js
@@ -283,3 +283,21 @@ tap.test(
     ])
   }
 )
+
+tap.test('Adds --provenance flag when provenance option provided', async () => {
+  const { publishToNpmProxy, execWithOutputStub } = setup()
+  await publishToNpmProxy.publishToNpm({
+    npmToken: 'a-token',
+    opticUrl: 'https://optic-test.run.app/api/generate/',
+    npmTag: 'latest',
+    version: 'v5.1.3',
+    provenance: true,
+  })
+
+  sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
+    'publish',
+    '--tag',
+    'latest',
+    '--provenance',
+  ])
+})

--- a/test/release.test.js
+++ b/test/release.test.js
@@ -216,7 +216,7 @@ tap.test('Should publish to npm without optic', async () => {
   })
 })
 
-tap.only(
+tap.test(
   'Should publish with provenance if flag set and conditions met',
   async () => {
     const { release, stubs } = setup({
@@ -242,7 +242,7 @@ tap.only(
   }
 )
 
-tap.only('Aborts publish with provenance if NPM version too old', async () => {
+tap.test('Aborts publish with provenance if NPM version too old', async () => {
   const { release, stubs } = setup({
     npmVersion: '9.4.0', // too old (is before 9.5.0)
     env: { ACTIONS_ID_TOKEN_REQUEST_URL: 'https://example.com' }, // valid
@@ -263,7 +263,7 @@ tap.only('Aborts publish with provenance if NPM version too old', async () => {
   )
 })
 
-tap.only('Aborts publish with provenance if missing permission', async () => {
+tap.test('Aborts publish with provenance if missing permission', async () => {
   const { release, stubs } = setup({
     npmVersion: '9.5.0', // valid, but before missing var is correctly handled on NPM's side (9.6.1)
     // missing ACTIONS_ID_TOKEN_REQUEST_URL which is set from `id-token: write` permission.


### PR DESCRIPTION
closes https://github.com/nearform-actions/optic-release-automation-action/issues/285

Adds [provenance](https://github.blog/2023-04-19-introducing-npm-package-provenance/) support, with:

 - Guards against silent failure or known misleading errors from NPM
 - Basic usage documentation
 - Unit tests and basic integration-like test cases in "release" tests