### PR TITLE
fix(issue 295): ensure inputs don't leak to child processes

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79558,16 +79558,19 @@ const { exec } = __nccwpck_require__(1514)
  * @param {{cwd?: string}} options
  * @returns Promise<string>
  */
-async function execWithOutput(cmd, args, { cwd } = {}) {
+async function execWithOutput(
+  cmd,
+  args,
+  { cwd, env = getFilteredEnv(), ...options } = {}
+) {
   let output = ''
   let errorOutput = ''
 
   const stdoutDecoder = new StringDecoder('utf8')
   const stderrDecoder = new StringDecoder('utf8')
 
-  const options = {
-    silent: false,
-  }
+  options.silent = false
+  options.env = env
 
   /* istanbul ignore else */
   if (cwd !== '') {
@@ -79610,6 +79613,21 @@ async function execWithOutput(cmd, args, { cwd } = {}) {
     `${cmd} ${args.join(
       ' '
     )} returned code ${code} \nSTDOUT: ${output}\nSTDERR: ${errorOutput}`
+  )
+}
+
+/**
+ * By default, `@actions/exec` 1.x's exec method copies all env vars to the child process,
+ * This includes `INPUT_*` vars that are specific to this action. This can leak repo secrets,
+ * such as the user's NPM_TOKEN and OPTIC_TOKEN. It's recommended to filter these.
+ * This may become the default behaviour in a future `@actions/exec` major release.
+ * @see https://github.com/actions/toolkit/issues/309
+ *
+ * @returns {Record<string, any>}
+ */
+function getFilteredEnv() {
+  return Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith('INPUT_'))
   )
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -79628,7 +79628,7 @@ async function execWithOutput(
   }
 
   throw new Error(
-    `${cmd} ${args.join(
+    `${cmd} ${args?.join(
       ' '
     )} returned code ${code} \nSTDOUT: ${output}\nSTDERR: ${errorOutput}`
   )

--- a/dist/index.js
+++ b/dist/index.js
@@ -79561,7 +79561,7 @@ const { exec } = __nccwpck_require__(1514)
 async function execWithOutput(
   cmd,
   args,
-  { cwd, env = getFilteredEnv(), ...options } = {}
+  { cwd, silent = false, env = getFilteredEnv(), ...options } = {}
 ) {
   let output = ''
   let errorOutput = ''
@@ -79569,7 +79569,7 @@ async function execWithOutput(
   const stdoutDecoder = new StringDecoder('utf8')
   const stderrDecoder = new StringDecoder('utf8')
 
-  options.silent = false
+  options.silent = silent
   options.env = env
 
   /* istanbul ignore else */

--- a/src/utils/execWithOutput.js
+++ b/src/utils/execWithOutput.js
@@ -63,7 +63,7 @@ async function execWithOutput(
   }
 
   throw new Error(
-    `${cmd} ${args.join(
+    `${cmd} ${args?.join(
       ' '
     )} returned code ${code} \nSTDOUT: ${output}\nSTDERR: ${errorOutput}`
   )

--- a/src/utils/execWithOutput.js
+++ b/src/utils/execWithOutput.js
@@ -14,7 +14,7 @@ const { exec } = require('@actions/exec')
 async function execWithOutput(
   cmd,
   args,
-  { cwd, env = getFilteredEnv(), ...options } = {}
+  { cwd, silent = false, env = getFilteredEnv(), ...options } = {}
 ) {
   let output = ''
   let errorOutput = ''
@@ -22,7 +22,7 @@ async function execWithOutput(
   const stdoutDecoder = new StringDecoder('utf8')
   const stderrDecoder = new StringDecoder('utf8')
 
-  options.silent = false
+  options.silent = silent
   options.env = env
 
   /* istanbul ignore else */

--- a/test/execWithOutput.test.js
+++ b/test/execWithOutput.test.js
@@ -71,3 +71,35 @@ tap.test('rejects if exit code is not 0', async t => {
   t.rejects(execWithOutputModule.execWithOutput('command'))
   execStub.calledWith('command')
 })
+
+tap.only('passes env vars excluding `INPUT_*` env vars', async t => {
+  const INPUT_NPM_TOKEN = 'some-secret-value'
+  const INPUT_OPTIC_TOKEN = 'another-secret-value'
+  const ACTIONS_ID_TOKEN_REQUEST_URL = 'https://example.com'
+  const GITHUB_EVENT_NAME = 'someEvent'
+
+  sinon.stub(process, 'env').value({
+    ...process.env,
+    INPUT_NPM_TOKEN,
+    INPUT_OPTIC_TOKEN,
+    ACTIONS_ID_TOKEN_REQUEST_URL,
+    GITHUB_EVENT_NAME,
+  })
+
+  execStub.resolves(0)
+  execWithOutputModule.execWithOutput('command', [])
+
+  const envInExec = execStub.firstCall.lastArg.env
+
+  // Check custom env vars are preserved
+  t.has(envInExec, { ACTIONS_ID_TOKEN_REQUEST_URL })
+  t.has(envInExec, { GITHUB_EVENT_NAME })
+
+  // Check INPUT_* env vars are removed
+  t.notHas(envInExec, { INPUT_NPM_TOKEN })
+  t.notHas(envInExec, { INPUT_OPTIC_TOKEN })
+
+  // Check "real" env vars are preserved.
+  // Its value will vary by test runner, so just check it is present.
+  t.hasProp(envInExec, 'NODE')
+})

--- a/test/execWithOutput.test.js
+++ b/test/execWithOutput.test.js
@@ -72,7 +72,7 @@ tap.test('rejects if exit code is not 0', async t => {
   execStub.calledWith('command')
 })
 
-tap.only('passes env vars excluding `INPUT_*` env vars', async t => {
+tap.test('passes env vars excluding `INPUT_*` env vars', async t => {
   const INPUT_NPM_TOKEN = 'some-secret-value'
   const INPUT_OPTIC_TOKEN = 'another-secret-value'
   const ACTIONS_ID_TOKEN_REQUEST_URL = 'https://example.com'


### PR DESCRIPTION
closes https://github.com/nearform-actions/optic-release-automation-action/issues/295

I split this out from the provenance work because it's a separate issue, posting this as an example implementation if we do think it's something worth doing. Not sure if it should have tests or not or if it's really possible to test?