### PR TITLE
feat: add `access`, fix provenance if new & unscoped

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ jobs:
 | `prerelease-prefix`       | No       | A prefix to apply to the prerelease version number.                                                                                                                                                                                                                                         |
 | `base-tag`       | No       | Choose a specific tag release for your release notes. This input allows you to specify a base release (for example, v1.0.0) and will include all changes made in releases between the base release and the latest release. This input is only used for generating release notes and has no functional implications on the rest of the workflow.                                                                                                                                                                                                                                         |
 | `provenance`| No    | Set as true to have NPM [generate a provenance statement](https://docs.npmjs.com/generating-provenance-statements). See [Provenance section above](#provenance) for requirements.<br /> (_Default: `false`_)      
-| `access`| No    | Set as `public` or `restricted` to change an NPM package's access status when next published. (_Default: `false`_)
+| `access`| No    | Set as `public` or `restricted` to change an NPM package's access status when next published.
 
 
 ## Motivation

--- a/README.md
+++ b/README.md
@@ -98,9 +98,6 @@ jobs:
           optic-token: ${{ secrets.OPTIC_TOKEN }}
           # optional: NPM will generate provenance statement, or abort release if it can't 
           provenance: true
-           # optional: requires to be public in order to enable provenance
-           # caution: this will make your npm package public
-          access: "public"
 ```
 
 The above workflow (when manually triggered) will:

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ When you merge this PR:
 - Upon successful retrieval of the OTP, it will publish the package to Npm.
 - Create a Github release with change logs (You can customize release notes using [release.yml](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configuration))
 - Leave a comment on each issues that are linked to the pull reqeuests of this release. This feature can be turned off by the `notify-on-the-issue` flag.
-- _(Optional)_ If `provenance: true` and npm package access is public, NPM will add a [Provenance](#provenance) notice to the package's public NPM page. *New packages will disable provenance.*
+- _(Optional)_ If `provenance: true`, NPM will add a [Provenance](#provenance) notice to the package's public NPM page.
 
 When you close the PR without merging it: nothing will happen.
 
@@ -235,7 +235,7 @@ If `provenance: true` is added to your `release.yml`'s **inputs**, NPM will [gen
 NPM has some internal [requirements](https://docs.npmjs.com/generating-provenance-statements#prerequisites) for generating provenance. Unfortunately as of May 2023, not all are documented by NPM; some key requirements are:
 
 - `id-token: write` must be added to your `release.yml`'s **permissions**
-- `access: 'public'` must be added to your `release.yml`'s **inputs** :warning: **This will make your npm package public**
+- The package must have public access.
 - NPM must be on version 9.5.0 or greater (this will be met if our recommended `runs-on: ubuntu-latest` is used)
 - NPM has some undocumented internal requirements on `package.json` completeness. For example, the [repository field](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repository) is required, and some NPM versions may require its `"url"` property to match the format `"git+https://github.com/user/repo"`.
 
@@ -263,9 +263,6 @@ jobs:
           npm-tag: ${{ github.event.inputs.tag }}
           # add this to activate the action's provenance feature
           provenance: true
-          # set this to true which is required for provenance
-          # caution: this will make your npm package public
-          access: 'public'
 ```
 
 
@@ -292,8 +289,7 @@ jobs:
 | `prerelease-prefix`       | No       | A prefix to apply to the prerelease version number.                                                                                                                                                                                                                                         |
 | `base-tag`       | No       | Choose a specific tag release for your release notes. This input allows you to specify a base release (for example, v1.0.0) and will include all changes made in releases between the base release and the latest release. This input is only used for generating release notes and has no functional implications on the rest of the workflow.                                                                                                                                                                                                                                         |
 | `provenance`| No    | Set as true to have NPM [generate a provenance statement](https://docs.npmjs.com/generating-provenance-statements). See [Provenance section above](#provenance) for requirements.<br /> (_Default: `false`_)      
-                                                                                                                   |
-| `provenance`| No    | Set as `public` to allow [generate a provenance statement](https://docs.npmjs.com/generating-provenance-statements). See [Provenance section above](#provenance) for requirements.<br /> (_Default: `private`_)                                                                  |
+| `access`| No    | Set as `public` or `restricted` to change an NPM package's access status when next published. (_Default: `false`_)
 
 
 ## Motivation

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ jobs:
           optic-token: ${{ secrets.OPTIC_TOKEN }}
           # optional: NPM will generate provenance statement, or abort release if it can't 
           provenance: true
+           # optional: requires to be public in order to enable provenance
+           # caution: this will make your npm package public
+          access: "public"
 ```
 
 The above workflow (when manually triggered) will:
@@ -117,7 +120,7 @@ When you merge this PR:
 - Upon successful retrieval of the OTP, it will publish the package to Npm.
 - Create a Github release with change logs (You can customize release notes using [release.yml](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configuration))
 - Leave a comment on each issues that are linked to the pull reqeuests of this release. This feature can be turned off by the `notify-on-the-issue` flag.
-- _(Optional)_ If `provenance: true` was set, NPM will add a [Provenance](#provenance) notice to the package's public NPM page.
+- _(Optional)_ If `provenance: true` and npm package access is public, NPM will add a [Provenance](#provenance) notice to the package's public NPM page. *New packages will disable provenance.*
 
 When you close the PR without merging it: nothing will happen.
 
@@ -232,6 +235,7 @@ If `provenance: true` is added to your `release.yml`'s **inputs**, NPM will [gen
 NPM has some internal [requirements](https://docs.npmjs.com/generating-provenance-statements#prerequisites) for generating provenance. Unfortunately as of May 2023, not all are documented by NPM; some key requirements are:
 
 - `id-token: write` must be added to your `release.yml`'s **permissions**
+- `access: 'public'` must be added to your `release.yml`'s **inputs** :warning: **This will make your npm package public**
 - NPM must be on version 9.5.0 or greater (this will be met if our recommended `runs-on: ubuntu-latest` is used)
 - NPM has some undocumented internal requirements on `package.json` completeness. For example, the [repository field](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repository) is required, and some NPM versions may require its `"url"` property to match the format `"git+https://github.com/user/repo"`.
 
@@ -259,6 +263,9 @@ jobs:
           npm-tag: ${{ github.event.inputs.tag }}
           # add this to activate the action's provenance feature
           provenance: true
+          # set this to true which is required for provenance
+          # caution: this will make your npm package public
+          access: 'public'
 ```
 
 
@@ -284,7 +291,9 @@ jobs:
 | `version-prefix`       | No       | A prefix to apply to the version number, which reflects in the tag and GitHub release names. <br /> (_Default: 'v'_)                                                                                                                                                                                                                                         |
 | `prerelease-prefix`       | No       | A prefix to apply to the prerelease version number.                                                                                                                                                                                                                                         |
 | `base-tag`       | No       | Choose a specific tag release for your release notes. This input allows you to specify a base release (for example, v1.0.0) and will include all changes made in releases between the base release and the latest release. This input is only used for generating release notes and has no functional implications on the rest of the workflow.                                                                                                                                                                                                                                         |
-| `provenance`| No    | Set as true to have NPM [generate a provenance statement](https://docs.npmjs.com/generating-provenance-statements). See [Provenance section above](#provenance) for requirements.<br /> (_Default: `false`_)                                                                  |
+| `provenance`| No    | Set as true to have NPM [generate a provenance statement](https://docs.npmjs.com/generating-provenance-statements). See [Provenance section above](#provenance) for requirements.<br /> (_Default: `false`_)      
+                                                                                                                   |
+| `provenance`| No    | Set as `public` to allow [generate a provenance statement](https://docs.npmjs.com/generating-provenance-statements). See [Provenance section above](#provenance) for requirements.<br /> (_Default: `private`_)                                                                  |
 
 
 ## Motivation

--- a/action.yml
+++ b/action.yml
@@ -81,9 +81,8 @@ inputs:
     type: boolean
     default: 'false'
   access:
-    description: 'If public any existing packages with provenance set to true will display provenance See https://docs.npmjs.com/generating-provenance-statements'
+    description: 'If defined, sets package to public or restricted via `--access` flag on `npm publish`. Supported values are "restricted" or "public".'
     required: false
-    default: 'private'
 
 runs:
   using: 'composite'

--- a/action.yml
+++ b/action.yml
@@ -80,6 +80,10 @@ inputs:
     required: false
     type: boolean
     default: 'false'
+  access:
+    description: 'If public any existing packages with provenance set to true will display provenance See https://docs.npmjs.com/generating-provenance-statements'
+    required: false
+    default: 'private'
 
 runs:
   using: 'composite'

--- a/dist/index.js
+++ b/dist/index.js
@@ -78934,6 +78934,7 @@ module.exports = {
   ZIP_EXTENSION: '.zip',
   APP_NAME: 'optic-release-automation[bot]',
   AUTO_INPUT: 'auto',
+  ACCESS_OPTIONS: ['public', 'restricted'],
 }
 
 
@@ -79211,7 +79212,7 @@ module.exports = async function ({ context, inputs, packageVersion }) {
 const core = __nccwpck_require__(2186)
 const semver = __nccwpck_require__(1383)
 
-const { PR_TITLE_PREFIX } = __nccwpck_require__(6818)
+const { ACCESS_OPTIONS, PR_TITLE_PREFIX } = __nccwpck_require__(6818)
 const { callApi } = __nccwpck_require__(4235)
 const { tagVersionInGit } = __nccwpck_require__(9143)
 const { revertCommit } = __nccwpck_require__(5765)
@@ -79311,10 +79312,9 @@ module.exports = async function ({ github, context, inputs }) {
     const access = inputs['access']
 
     // Can't limit custom action inputs to fixed options like "choice" type in a manual action
-    const validAccessOptions = ['public', 'restricted']
-    if (access && !validAccessOptions.includes(access)) {
+    if (access && !ACCESS_OPTIONS.includes(access)) {
       core.setFailed(
-        `Invalid "access" option provided ("${access}"), should be one of "${validAccessOptions.join(
+        `Invalid "access" option provided ("${access}"), should be one of "${ACCESS_OPTIONS.join(
           '", "'
         )}"`
       )

--- a/dist/index.js
+++ b/dist/index.js
@@ -79947,7 +79947,7 @@ async function getAccessAdjustment({ access } = {}) {
 
 /**
  * Fail fast and throw a meaningful error if NPM Provenance will fail silently or misleadingly,
- * and where necessary, tweak publish options without overriding user preferences or expectations.
+ * and where necessary, provide new publish options without overriding user preferences or expectations.
  *
  * @see https://docs.npmjs.com/generating-provenance-statements
  */
@@ -79956,9 +79956,9 @@ async function ensureProvenanceViability(npmVersion, publishOptions) {
   checkIsSupported(npmVersion)
   checkPermissions(npmVersion)
 
-  return {
-    ...getAccessAdjustment(publishOptions),
-  }
+  const optionAdjustments = await getAccessAdjustment(publishOptions)
+
+  return optionAdjustments ?? {}
 }
 
 /**

--- a/dist/index.js
+++ b/dist/index.js
@@ -79311,9 +79311,13 @@ module.exports = async function ({ github, context, inputs }) {
     const access = inputs['access']
 
     // Can't limit custom action inputs to fixed options like "choice" type in a manual action
-    const validAccessOptions = ['public', 'restricted'] 
+    const validAccessOptions = ['public', 'restricted']
     if (access && !validAccessOptions.includes(access)) {
-      core.setFailed(`Invalid "access" option provided ("${access}"), should be one of "${validAccessOptions.join('", "')}"`)
+      core.setFailed(
+        `Invalid "access" option provided ("${access}"), should be one of "${validAccessOptions.join(
+          '", "'
+        )}"`
+      )
       return
     }
 
@@ -79324,14 +79328,17 @@ module.exports = async function ({ github, context, inputs }) {
       npmTag,
       version,
       provenance,
-      access
+      access,
     }
 
     if (provenance) {
       // Fail fast with meaningful error if user wants provenance but their setup won't deliver,
       // and apply any necessary options tweaks.
       const npmVersion = await getNpmVersion()
-      publishOptions = await ensureProvenanceViability(npmVersion, publishOptions)
+      publishOptions = await ensureProvenanceViability(
+        npmVersion,
+        publishOptions
+      )
     }
 
     if (npmToken) {
@@ -79823,7 +79830,7 @@ const { execWithOutput } = __nccwpck_require__(8632)
 
 /**
  * Get info from the registry about a package that is already published.
- * 
+ *
  * Returns null if package is not published to NPM.
  */
 async function getPublishedInfo() {
@@ -79840,9 +79847,9 @@ async function getPublishedInfo() {
 
 /**
  * Get info from the local package.json file.
- * 
+ *
  * This might need to become a bit more sophisticated if support for monorepos is added,
- * @see https://github.com/nearform-actions/optic-release-automation-action/issues/177 
+ * @see https://github.com/nearform-actions/optic-release-automation-action/issues/177
  */
 function getLocalInfo() {
   const packageJsonFile = fs.readFileSync('./package.json', 'utf8')
@@ -79866,7 +79873,7 @@ module.exports = {
 
 const semver = __nccwpck_require__(1383)
 const { execWithOutput } = __nccwpck_require__(8632)
-const { getLocalInfo, getPublishedInfo, isPackageNameScoped } = __nccwpck_require__(4349)
+const { getLocalInfo, getPublishedInfo } = __nccwpck_require__(4349)
 
 /**
  * Abort if the user specified they want NPM provenance, but their CI's NPM version doesn't support it.
@@ -79950,7 +79957,7 @@ async function ensureProvenanceViability(npmVersion, publishOptions) {
 
   const value = {
     ...publishOptions,
-    ...await getAccessAdjustment(publishOptions),
+    ...(await getAccessAdjustment(publishOptions)),
   }
   return value
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -79328,13 +79328,13 @@ module.exports = async function ({ github, context, inputs }) {
     }
 
     if (provenance) {
-      // Fail fast with meaningful errors if user wants provenance but their setup won't deliver,
-      // and apply any necessary options tweaks.
-      const npmVersion = await getNpmVersion()
-      Object.assign(
-        publishOptions,
-        await getProvenanceOptions(npmVersion, publishOptions)
+      const extraOptions = await getProvenanceOptions(
+        await getNpmVersion(),
+        publishOptions
       )
+      if (extraOptions) {
+        Object.assign(publishOptions, extraOptions)
+      }
     }
 
     if (npmToken) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -79220,7 +79220,7 @@ const { notifyIssues } = __nccwpck_require__(8361)
 const { logError, logInfo, logWarning } = __nccwpck_require__(653)
 const { execWithOutput } = __nccwpck_require__(8632)
 const {
-  checkProvenanceViability,
+  ensureProvenanceViability,
   getNpmVersion,
 } = __nccwpck_require__(3365)
 
@@ -79317,22 +79317,25 @@ module.exports = async function ({ github, context, inputs }) {
       return
     }
 
-    // Fail fast with meaningful error if user wants provenance but their setup won't deliver
+    let publishOptions = {
+      npmToken,
+      opticToken,
+      opticUrl,
+      npmTag,
+      version,
+      provenance,
+      access
+    }
+
     if (provenance) {
+      // Fail fast with meaningful error if user wants provenance but their setup won't deliver,
+      // and apply any necessary options tweaks.
       const npmVersion = await getNpmVersion()
-      checkProvenanceViability(npmVersion)
+      publishOptions = await ensureProvenanceViability(npmVersion, publishOptions)
     }
 
     if (npmToken) {
-      await publishToNpm({
-        npmToken,
-        opticToken,
-        opticUrl,
-        npmTag,
-        version,
-        provenance,
-        access
-      })
+      await publishToNpm(publishOptions)
     } else {
       logWarning('missing npm-token')
     }
@@ -79669,11 +79672,11 @@ exports.execWithOutput = execWithOutput
 "use strict";
 
 
-const fs = __nccwpck_require__(7147)
 const pMap = __nccwpck_require__(1855)
 const { logWarning } = __nccwpck_require__(653)
 
 const { getPrNumbersFromReleaseNotes } = __nccwpck_require__(4098)
+const { getLocalInfo } = __nccwpck_require__(4349)
 
 async function getLinkedIssueNumbers(github, prNumber, repoOwner, repoName) {
   const data = await github.graphql(
@@ -79756,8 +79759,7 @@ async function notifyIssues(
   repo,
   release
 ) {
-  const packageJsonFile = fs.readFileSync('./package.json', 'utf8')
-  const packageJson = JSON.parse(packageJsonFile)
+  const packageJson = getLocalInfo()
 
   const { name: packageName, version: packageVersion } = packageJson
   const { body: releaseNotes, html_url: releaseUrl } = release
@@ -79811,6 +79813,52 @@ exports.notifyIssues = notifyIssues
 
 /***/ }),
 
+/***/ 4349:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+const fs = __nccwpck_require__(7147)
+const { execWithOutput } = __nccwpck_require__(8632)
+
+/**
+ * Get info from the registry about a package that is already published.
+ * 
+ * Returns null if package is not published to NPM.
+ */
+async function getPublishedInfo() {
+  try {
+    const packageInfo = await execWithOutput('npm', ['view', '--json'])
+    return packageInfo ? JSON.parse(packageInfo) : null
+  } catch (error) {
+    if (!error?.message?.match(/code E404/)) {
+      throw error
+    }
+    return null
+  }
+}
+
+/**
+ * Get info from the local package.json file.
+ * 
+ * This might need to become a bit more sophisticated if support for monorepos is added,
+ * @see https://github.com/nearform-actions/optic-release-automation-action/issues/177 
+ */
+function getLocalInfo() {
+  const packageJsonFile = fs.readFileSync('./package.json', 'utf8')
+  const packageInfo = JSON.parse(packageJsonFile)
+
+  return packageInfo
+}
+
+module.exports = {
+  getLocalInfo,
+  getPublishedInfo,
+}
+
+
+/***/ }),
+
 /***/ 3365:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -79818,6 +79866,7 @@ exports.notifyIssues = notifyIssues
 
 const semver = __nccwpck_require__(1383)
 const { execWithOutput } = __nccwpck_require__(8632)
+const { getLocalInfo, getPublishedInfo, isPackageNameScoped } = __nccwpck_require__(4349)
 
 /**
  * Abort if the user specified they want NPM provenance, but their CI's NPM version doesn't support it.
@@ -79857,30 +79906,53 @@ function checkPermissions(npmVersion) {
 }
 
 /**
- * Fail fast and throw a meaningful error if NPM Provenance will fail silently or misleadingly.
- *
- * @see https://docs.npmjs.com/generating-provenance-statements
- *
- * @param {string} npmVersion
- * @param {boolean} hasAccess optional, defaults to false for private default access
+ * NPM does an internal check on access that fails unnecessarily for first-time publication
+ * of unscoped packages to NPM. Unscoped packages are always public, but NPM's provenance generation
+ * doesn't realise this unless it sees the status in a previous release or in explicit options.
  */
-function checkProvenanceViability(npmVersion, hasAccess) {
-  if (!npmVersion) throw new Error('Current npm version not provided')
-  checkIsSupported(npmVersion)
-  checkPermissions(npmVersion)
-  checkAccessViability(hasAccess)
-  // There are various other provenance requirements, such as specific package.json properties, but these
-  // may change in future NPM versions, and do fail with meaningful errors, so we let NPM handle those.
+async function getAccessAdjustment({ access } = {}) {
+  // Don't overrule any user-set access preference.
+  if (access) return
+
+  const { name: packageName, publishConfig } = getLocalInfo()
+
+  // Don't do anything for scoped packages - those require being made public explicitly.
+  // Let NPM's own validation handle it if a user tries to get provenance on a private package.
+  // `.startsWith('@')` is what a lot of NPM internal code use to detect scoped packages,
+  // they don't export any more sophisticated scoped name detector any more.
+  if (packageName.startsWith('@')) return
+
+  // Don't do anything if the user has set any access control in package.json publishConfig.
+  // https://docs.npmjs.com/cli/v9/configuring-npm/package-json#publishconfig
+  // Let NPM deal with that internally when `npm publish` reads the local package.json file.
+  if (publishConfig?.access) return
+
+  // Don't do anything if package is already published.
+  const publishedInfo = await getPublishedInfo()
+  if (publishedInfo) return
+
+  // Set explicit public access **only** if it's unscoped (inherently public), a first publish
+  // (so we know NPM will fail to realise that this is inherently public), and the user
+  // has not attempted to explicitly set access themselves anywhere.
+  return { access: 'public' }
 }
 
 /**
- * Fail fast and throw a meaningful error if Access doesn't allow Provenance
- * @see https://docs.npmjs.com/generating-provenance-statements
+ * Fail fast and throw a meaningful error if NPM Provenance will fail silently or misleadingly,
+ * and where necessary, tweak publish options without overriding user preferences or expectations.
  *
- * @param {boolean} hasAccess optional, defaults to false for private default access
+ * @see https://docs.npmjs.com/generating-provenance-statements
  */
-function checkAccessViability(hasAccess) {
-  if (false) {}
+async function ensureProvenanceViability(npmVersion, publishOptions) {
+  if (!npmVersion) throw new Error('Current npm version not provided')
+  checkIsSupported(npmVersion)
+  checkPermissions(npmVersion)
+
+  const value = {
+    ...publishOptions,
+    ...await getAccessAdjustment(publishOptions),
+  }
+  return value
 }
 
 /**
@@ -79892,8 +79964,9 @@ async function getNpmVersion() {
 }
 
 module.exports = {
-  checkProvenanceViability,
+  ensureProvenanceViability,
   getNpmVersion,
+  getAccessAdjustment,
   checkIsSupported,
   checkPermissions,
 }
@@ -79908,27 +79981,15 @@ module.exports = {
 
 
 const { execWithOutput } = __nccwpck_require__(8632)
-async function getPackageName() {
-  let packageName = null
-  try {
-    const packageInfo = await execWithOutput('npm', ['view', '--json'])
-    packageName = packageInfo ? JSON.parse(packageInfo).name : null
-  } catch (error) {
-    // It'll 404 if package is unpublished (or we lack access): return null and continue
-    if (!error?.message?.match(/code E404/)) {
-      // Throw if we see an unexpected error
-      throw error
-    }
-  }
+const { getPublishedInfo } = __nccwpck_require__(4349)
 
-  return packageName
-}
 async function allowNpmPublish(version) {
   // We need to check if the package was already published. This can happen if
   // the action was already executed before, but it failed in its last step
   // (GH release).
 
-  const packageName = await getPackageName()
+  const packageInfo = await getPublishedInfo()
+  const packageName = packageInfo?.name
   // Package has not been published before
   if (!packageName) {
     return true
@@ -79954,18 +80015,7 @@ async function allowNpmPublish(version) {
 
   return !packageVersionInfo
 }
-/**
- * 
- * @param {
- *  npmToken,
-    opticToken,
-    opticUrl,
-    npmTag,
-    version,
-    provenance: boolean
-    hasAccess: boolean
- * }  
- */
+
 async function publishToNpm({
   npmToken,
   opticToken,
@@ -79973,7 +80023,7 @@ async function publishToNpm({
   npmTag,
   version,
   provenance,
-  hasAccess,
+  access,
 }) {
   await execWithOutput('npm', [
     'config',
@@ -79981,12 +80031,14 @@ async function publishToNpm({
     `//registry.npmjs.org/:_authToken=${npmToken}`,
   ])
 
-  const packageName = await getPackageName()
-
   const flags = ['--tag', npmTag]
-  // new packages and private packages disable provenance, they need to be public
-  if (hasAccess && provenance) {
-    flags.push('--provenance', '--access', 'public')
+
+  if (access) {
+    flags.push('--access', access)
+  }
+
+  if (provenance) {
+    flags.push('--provenance')
   }
 
   if (await allowNpmPublish(version)) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -79906,11 +79906,7 @@ module.exports = {
 
 
 const { execWithOutput } = __nccwpck_require__(8632)
-
-async function allowNpmPublish(version) {
-  // We need to check if the package was already published. This can happen if
-  // the action was already executed before, but it failed in its last step
-  // (GH release).
+async function getPackageName() {
   let packageName = null
   try {
     const packageInfo = await execWithOutput('npm', ['view', '--json'])
@@ -79921,6 +79917,14 @@ async function allowNpmPublish(version) {
     }
   }
 
+  return packageName
+}
+async function allowNpmPublish(version) {
+  // We need to check if the package was already published. This can happen if
+  // the action was already executed before, but it failed in its last step
+  // (GH release).
+
+  const packageName = getPackageName()
   // Package has not been published before
   if (!packageName) {
     return true
@@ -79973,15 +79977,7 @@ async function publishToNpm({
     `//registry.npmjs.org/:_authToken=${npmToken}`,
   ])
 
-  let packageName = null
-  try {
-    const packageInfo = await execWithOutput('npm', ['view', '--json'])
-    packageName = packageInfo ? JSON.parse(packageInfo).name : null
-  } catch (error) {
-    if (!error?.message?.match(/code E404/)) {
-      throw error
-    }
-  }
+  const packageName = getPackageName()
 
   const flags = ['--tag', npmTag]
   // new packages and private packages disable provenance, they need to be public

--- a/dist/index.js
+++ b/dist/index.js
@@ -79321,7 +79321,7 @@ module.exports = async function ({ github, context, inputs }) {
       return
     }
 
-    let publishOptions = {
+    const publishOptions = {
       npmToken,
       opticToken,
       opticUrl,
@@ -79335,9 +79335,10 @@ module.exports = async function ({ github, context, inputs }) {
       // Fail fast with meaningful error if user wants provenance but their setup won't deliver,
       // and apply any necessary options tweaks.
       const npmVersion = await getNpmVersion()
-      publishOptions = await ensureProvenanceViability(
-        npmVersion,
-        publishOptions
+
+      Object.assign(
+        publishOptions,
+        await ensureProvenanceViability(npmVersion, publishOptions)
       )
     }
 
@@ -79955,11 +79956,9 @@ async function ensureProvenanceViability(npmVersion, publishOptions) {
   checkIsSupported(npmVersion)
   checkPermissions(npmVersion)
 
-  const value = {
-    ...publishOptions,
-    ...(await getAccessAdjustment(publishOptions)),
+  return {
+    ...getAccessAdjustment(publishOptions),
   }
-  return value
 }
 
 /**

--- a/src/const.js
+++ b/src/const.js
@@ -5,4 +5,5 @@ module.exports = {
   ZIP_EXTENSION: '.zip',
   APP_NAME: 'optic-release-automation[bot]',
   AUTO_INPUT: 'auto',
+  ACCESS_OPTIONS: ['public', 'restricted'],
 }

--- a/src/release.js
+++ b/src/release.js
@@ -3,7 +3,7 @@
 const core = require('@actions/core')
 const semver = require('semver')
 
-const { PR_TITLE_PREFIX } = require('./const')
+const { ACCESS_OPTIONS, PR_TITLE_PREFIX } = require('./const')
 const { callApi } = require('./utils/callApi')
 const { tagVersionInGit } = require('./utils/tagVersion')
 const { revertCommit } = require('./utils/revertCommit')
@@ -103,10 +103,9 @@ module.exports = async function ({ github, context, inputs }) {
     const access = inputs['access']
 
     // Can't limit custom action inputs to fixed options like "choice" type in a manual action
-    const validAccessOptions = ['public', 'restricted']
-    if (access && !validAccessOptions.includes(access)) {
+    if (access && !ACCESS_OPTIONS.includes(access)) {
       core.setFailed(
-        `Invalid "access" option provided ("${access}"), should be one of "${validAccessOptions.join(
+        `Invalid "access" option provided ("${access}"), should be one of "${ACCESS_OPTIONS.join(
           '", "'
         )}"`
       )

--- a/src/release.js
+++ b/src/release.js
@@ -113,7 +113,7 @@ module.exports = async function ({ github, context, inputs }) {
       return
     }
 
-    let publishOptions = {
+    const publishOptions = {
       npmToken,
       opticToken,
       opticUrl,
@@ -127,9 +127,10 @@ module.exports = async function ({ github, context, inputs }) {
       // Fail fast with meaningful error if user wants provenance but their setup won't deliver,
       // and apply any necessary options tweaks.
       const npmVersion = await getNpmVersion()
-      publishOptions = await ensureProvenanceViability(
-        npmVersion,
-        publishOptions
+
+      Object.assign(
+        publishOptions,
+        await ensureProvenanceViability(npmVersion, publishOptions)
       )
     }
 

--- a/src/release.js
+++ b/src/release.js
@@ -102,7 +102,6 @@ module.exports = async function ({ github, context, inputs }) {
     const provenance = /true/i.test(inputs['provenance'])
     const access = inputs['access']
 
-    // Can't limit custom action inputs to fixed options like "choice" type in a manual action
     if (access && !ACCESS_OPTIONS.includes(access)) {
       core.setFailed(
         `Invalid "access" option provided ("${access}"), should be one of "${ACCESS_OPTIONS.join(

--- a/src/release.js
+++ b/src/release.js
@@ -11,10 +11,7 @@ const { publishToNpm } = require('./utils/publishToNpm')
 const { notifyIssues } = require('./utils/notifyIssues')
 const { logError, logInfo, logWarning } = require('./log')
 const { execWithOutput } = require('./utils/execWithOutput')
-const {
-  ensureProvenanceViability,
-  getNpmVersion,
-} = require('./utils/provenance')
+const { getProvenanceOptions, getNpmVersion } = require('./utils/provenance')
 
 module.exports = async function ({ github, context, inputs }) {
   logInfo('** Starting Release **')
@@ -122,14 +119,13 @@ module.exports = async function ({ github, context, inputs }) {
     }
 
     if (provenance) {
-      // Fail fast with meaningful error if user wants provenance but their setup won't deliver,
-      // and apply any necessary options tweaks.
-      const npmVersion = await getNpmVersion()
-
-      Object.assign(
-        publishOptions,
-        await ensureProvenanceViability(npmVersion, publishOptions)
+      const extraOptions = await getProvenanceOptions(
+        await getNpmVersion(),
+        publishOptions
       )
+      if (extraOptions) {
+        Object.assign(publishOptions, extraOptions)
+      }
     }
 
     if (npmToken) {

--- a/src/release.js
+++ b/src/release.js
@@ -103,9 +103,13 @@ module.exports = async function ({ github, context, inputs }) {
     const access = inputs['access']
 
     // Can't limit custom action inputs to fixed options like "choice" type in a manual action
-    const validAccessOptions = ['public', 'restricted'] 
+    const validAccessOptions = ['public', 'restricted']
     if (access && !validAccessOptions.includes(access)) {
-      core.setFailed(`Invalid "access" option provided ("${access}"), should be one of "${validAccessOptions.join('", "')}"`)
+      core.setFailed(
+        `Invalid "access" option provided ("${access}"), should be one of "${validAccessOptions.join(
+          '", "'
+        )}"`
+      )
       return
     }
 
@@ -116,14 +120,17 @@ module.exports = async function ({ github, context, inputs }) {
       npmTag,
       version,
       provenance,
-      access
+      access,
     }
 
     if (provenance) {
       // Fail fast with meaningful error if user wants provenance but their setup won't deliver,
       // and apply any necessary options tweaks.
       const npmVersion = await getNpmVersion()
-      publishOptions = await ensureProvenanceViability(npmVersion, publishOptions)
+      publishOptions = await ensureProvenanceViability(
+        npmVersion,
+        publishOptions
+      )
     }
 
     if (npmToken) {

--- a/src/release.js
+++ b/src/release.js
@@ -100,12 +100,19 @@ module.exports = async function ({ github, context, inputs }) {
     const opticToken = inputs['optic-token']
     const npmToken = inputs['npm-token']
     const provenance = /true/i.test(inputs['provenance'])
-    const hasAccess = /'public'/i.test(inputs['access'])
+    const access = inputs['access']
+
+    // Can't limit custom action inputs to fixed options like "choice" type in a manual action
+    const validAccessOptions = ['public', 'restricted'] 
+    if (access && !validAccessOptions.includes(access)) {
+      core.setFailed(`Invalid "access" option provided ("${access}"), should be one of "${validAccessOptions.join('", "')}"`)
+      return
+    }
 
     // Fail fast with meaningful error if user wants provenance but their setup won't deliver
     if (provenance) {
       const npmVersion = await getNpmVersion()
-      checkProvenanceViability(npmVersion, hasAccess)
+      checkProvenanceViability(npmVersion)
     }
 
     if (npmToken) {
@@ -116,7 +123,7 @@ module.exports = async function ({ github, context, inputs }) {
         npmTag,
         version,
         provenance,
-        hasAccess
+        access
       })
     } else {
       logWarning('missing npm-token')

--- a/src/release.js
+++ b/src/release.js
@@ -100,11 +100,12 @@ module.exports = async function ({ github, context, inputs }) {
     const opticToken = inputs['optic-token']
     const npmToken = inputs['npm-token']
     const provenance = /true/i.test(inputs['provenance'])
+    const hasAccess = /'public'/i.test(inputs['access'])
 
     // Fail fast with meaningful error if user wants provenance but their setup won't deliver
     if (provenance) {
       const npmVersion = await getNpmVersion()
-      checkProvenanceViability(npmVersion)
+      checkProvenanceViability(npmVersion, hasAccess)
     }
 
     if (npmToken) {
@@ -115,6 +116,7 @@ module.exports = async function ({ github, context, inputs }) {
         npmTag,
         version,
         provenance,
+        hasAccess
       })
     } else {
       logWarning('missing npm-token')

--- a/src/utils/notifyIssues.js
+++ b/src/utils/notifyIssues.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const fs = require('fs')
 const pMap = require('p-map')
 const { logWarning } = require('../log')
 
 const { getPrNumbersFromReleaseNotes } = require('./releaseNotes')
+const { getLocalInfo } = require('../utils/packageInfo')
 
 async function getLinkedIssueNumbers(github, prNumber, repoOwner, repoName) {
   const data = await github.graphql(
@@ -87,8 +87,7 @@ async function notifyIssues(
   repo,
   release
 ) {
-  const packageJsonFile = fs.readFileSync('./package.json', 'utf8')
-  const packageJson = JSON.parse(packageJsonFile)
+  const packageJson = getLocalInfo()
 
   const { name: packageName, version: packageVersion } = packageJson
   const { body: releaseNotes, html_url: releaseUrl } = release

--- a/src/utils/packageInfo.js
+++ b/src/utils/packageInfo.js
@@ -4,7 +4,7 @@ const { execWithOutput } = require('../utils/execWithOutput')
 
 /**
  * Get info from the registry about a package that is already published.
- * 
+ *
  * Returns null if package is not published to NPM.
  */
 async function getPublishedInfo() {
@@ -21,9 +21,9 @@ async function getPublishedInfo() {
 
 /**
  * Get info from the local package.json file.
- * 
+ *
  * This might need to become a bit more sophisticated if support for monorepos is added,
- * @see https://github.com/nearform-actions/optic-release-automation-action/issues/177 
+ * @see https://github.com/nearform-actions/optic-release-automation-action/issues/177
  */
 function getLocalInfo() {
   const packageJsonFile = fs.readFileSync('./package.json', 'utf8')

--- a/src/utils/packageInfo.js
+++ b/src/utils/packageInfo.js
@@ -1,0 +1,38 @@
+'use strict'
+const fs = require('fs')
+const { execWithOutput } = require('../utils/execWithOutput')
+
+/**
+ * Get info from the registry about a package that is already published.
+ * 
+ * Returns null if package is not published to NPM.
+ */
+async function getPublishedInfo() {
+  try {
+    const packageInfo = await execWithOutput('npm', ['view', '--json'])
+    return packageInfo ? JSON.parse(packageInfo) : null
+  } catch (error) {
+    if (!error?.message?.match(/code E404/)) {
+      throw error
+    }
+    return null
+  }
+}
+
+/**
+ * Get info from the local package.json file.
+ * 
+ * This might need to become a bit more sophisticated if support for monorepos is added,
+ * @see https://github.com/nearform-actions/optic-release-automation-action/issues/177 
+ */
+function getLocalInfo() {
+  const packageJsonFile = fs.readFileSync('./package.json', 'utf8')
+  const packageInfo = JSON.parse(packageJsonFile)
+
+  return packageInfo
+}
+
+module.exports = {
+  getLocalInfo,
+  getPublishedInfo,
+}

--- a/src/utils/provenance.js
+++ b/src/utils/provenance.js
@@ -45,13 +45,27 @@ function checkPermissions(npmVersion) {
  * @see https://docs.npmjs.com/generating-provenance-statements
  *
  * @param {string} npmVersion
+ * @param {boolean} hasAccess optional, defaults to false for private default access 
  */
-function checkProvenanceViability(npmVersion) {
+function checkProvenanceViability(npmVersion, hasAccess) {
   if (!npmVersion) throw new Error('Current npm version not provided')
   checkIsSupported(npmVersion)
   checkPermissions(npmVersion)
+  checkAccessViability(hasAccess)
   // There are various other provenance requirements, such as specific package.json properties, but these
   // may change in future NPM versions, and do fail with meaningful errors, so we let NPM handle those.
+}
+
+/**
+ * Fail fast and throw a meaningful error if Access doesn't allow Provenance
+ * @see https://docs.npmjs.com/generating-provenance-statements
+ *
+ * @param {boolean} hasAccess optional, defaults to false for private default access 
+ */
+function checkAccessViability(hasAccess) {
+  if (!hasAccess) {
+    throw new Error('Can\'t generate provenance for new or private package, you must set access to public')
+  }
 }
 
 /**
@@ -64,6 +78,7 @@ async function getNpmVersion() {
 
 module.exports = {
   checkProvenanceViability,
+  checkAccessViability,
   getNpmVersion,
   checkIsSupported,
   checkPermissions,

--- a/src/utils/provenance.js
+++ b/src/utils/provenance.js
@@ -78,14 +78,14 @@ async function getAccessAdjustment({ access } = {}) {
  *
  * @see https://docs.npmjs.com/generating-provenance-statements
  */
-async function ensureProvenanceViability(npmVersion, publishOptions) {
+async function getProvenanceOptions(npmVersion, publishOptions) {
   if (!npmVersion) throw new Error('Current npm version not provided')
   checkIsSupported(npmVersion)
   checkPermissions(npmVersion)
 
-  const optionAdjustments = await getAccessAdjustment(publishOptions)
+  const extraOptions = await getAccessAdjustment(publishOptions)
 
-  return optionAdjustments ?? {}
+  return extraOptions
 }
 
 /**
@@ -97,7 +97,7 @@ async function getNpmVersion() {
 }
 
 module.exports = {
-  ensureProvenanceViability,
+  getProvenanceOptions,
   getNpmVersion,
   getAccessAdjustment,
   checkIsSupported,

--- a/src/utils/provenance.js
+++ b/src/utils/provenance.js
@@ -45,7 +45,7 @@ function checkPermissions(npmVersion) {
  * @see https://docs.npmjs.com/generating-provenance-statements
  *
  * @param {string} npmVersion
- * @param {boolean} hasAccess optional, defaults to false for private default access 
+ * @param {boolean} hasAccess optional, defaults to false for private default access
  */
 function checkProvenanceViability(npmVersion, hasAccess) {
   if (!npmVersion) throw new Error('Current npm version not provided')
@@ -60,11 +60,13 @@ function checkProvenanceViability(npmVersion, hasAccess) {
  * Fail fast and throw a meaningful error if Access doesn't allow Provenance
  * @see https://docs.npmjs.com/generating-provenance-statements
  *
- * @param {boolean} hasAccess optional, defaults to false for private default access 
+ * @param {boolean} hasAccess optional, defaults to false for private default access
  */
 function checkAccessViability(hasAccess) {
   if (!hasAccess) {
-    throw new Error('Can\'t generate provenance for new or private package, you must set access to public')
+    throw new Error(
+      "Can't generate provenance for new or private package, you must set access to public"
+    )
   }
 }
 

--- a/src/utils/provenance.js
+++ b/src/utils/provenance.js
@@ -1,7 +1,7 @@
 'use strict'
 const semver = require('semver')
 const { execWithOutput } = require('./execWithOutput')
-const { getLocalInfo, getPublishedInfo, isPackageNameScoped } = require('./packageInfo')
+const { getLocalInfo, getPublishedInfo } = require('./packageInfo')
 
 /**
  * Abort if the user specified they want NPM provenance, but their CI's NPM version doesn't support it.
@@ -85,7 +85,7 @@ async function ensureProvenanceViability(npmVersion, publishOptions) {
 
   const value = {
     ...publishOptions,
-    ...await getAccessAdjustment(publishOptions),
+    ...(await getAccessAdjustment(publishOptions)),
   }
   return value
 }

--- a/src/utils/provenance.js
+++ b/src/utils/provenance.js
@@ -74,7 +74,7 @@ async function getAccessAdjustment({ access } = {}) {
 
 /**
  * Fail fast and throw a meaningful error if NPM Provenance will fail silently or misleadingly,
- * and where necessary, tweak publish options without overriding user preferences or expectations.
+ * and where necessary, provide new publish options without overriding user preferences or expectations.
  *
  * @see https://docs.npmjs.com/generating-provenance-statements
  */
@@ -83,9 +83,9 @@ async function ensureProvenanceViability(npmVersion, publishOptions) {
   checkIsSupported(npmVersion)
   checkPermissions(npmVersion)
 
-  return {
-    ...getAccessAdjustment(publishOptions),
-  }
+  const optionAdjustments = await getAccessAdjustment(publishOptions)
+
+  return optionAdjustments ?? {}
 }
 
 /**

--- a/src/utils/provenance.js
+++ b/src/utils/provenance.js
@@ -83,11 +83,9 @@ async function ensureProvenanceViability(npmVersion, publishOptions) {
   checkIsSupported(npmVersion)
   checkPermissions(npmVersion)
 
-  const value = {
-    ...publishOptions,
-    ...(await getAccessAdjustment(publishOptions)),
+  return {
+    ...getAccessAdjustment(publishOptions),
   }
-  return value
 }
 
 /**

--- a/src/utils/provenance.js
+++ b/src/utils/provenance.js
@@ -45,29 +45,13 @@ function checkPermissions(npmVersion) {
  * @see https://docs.npmjs.com/generating-provenance-statements
  *
  * @param {string} npmVersion
- * @param {boolean} hasAccess optional, defaults to false for private default access
  */
-function checkProvenanceViability(npmVersion, hasAccess) {
+function checkProvenanceViability(npmVersion) {
   if (!npmVersion) throw new Error('Current npm version not provided')
   checkIsSupported(npmVersion)
   checkPermissions(npmVersion)
-  checkAccessViability(hasAccess)
   // There are various other provenance requirements, such as specific package.json properties, but these
   // may change in future NPM versions, and do fail with meaningful errors, so we let NPM handle those.
-}
-
-/**
- * Fail fast and throw a meaningful error if Access doesn't allow Provenance
- * @see https://docs.npmjs.com/generating-provenance-statements
- *
- * @param {boolean} hasAccess optional, defaults to false for private default access
- */
-function checkAccessViability(hasAccess) {
-  if (!hasAccess) {
-    throw new Error(
-      "Can't generate provenance for new or private package, you must set access to public"
-    )
-  }
 }
 
 /**
@@ -80,7 +64,6 @@ async function getNpmVersion() {
 
 module.exports = {
   checkProvenanceViability,
-  checkAccessViability,
   getNpmVersion,
   checkIsSupported,
   checkPermissions,

--- a/src/utils/publishToNpm.js
+++ b/src/utils/publishToNpm.js
@@ -60,7 +60,7 @@ async function publishToNpm({
   npmTag,
   version,
   provenance,
-  hasAccess
+  hasAccess,
 }) {
   await execWithOutput('npm', [
     'config',
@@ -77,7 +77,7 @@ async function publishToNpm({
       throw error
     }
   }
-  
+
   const flags = ['--tag', npmTag]
   // new packages and private packages disable provenance, they need to be public
   if (!packageName && hasAccess && provenance) {

--- a/src/utils/publishToNpm.js
+++ b/src/utils/publishToNpm.js
@@ -9,9 +9,8 @@ async function allowNpmPublish(version) {
   // (GH release).
 
   const packageInfo = await getPublishedInfo()
-  const packageName = packageInfo?.name
   // Package has not been published before
-  if (!packageName) {
+  if (!packageInfo?.name) {
     return true
   }
 
@@ -25,7 +24,7 @@ async function allowNpmPublish(version) {
     // We handle both and consider them as package version not existing
     packageVersionInfo = await execWithOutput('npm', [
       'view',
-      `${packageName}@${version}`,
+      `${packageInfo.name}@${version}`,
     ])
   } catch (error) {
     if (!error?.message?.match(/code E404/)) {

--- a/src/utils/publishToNpm.js
+++ b/src/utils/publishToNpm.js
@@ -1,25 +1,15 @@
 'use strict'
 
 const { execWithOutput } = require('./execWithOutput')
-async function getPackageName() {
-  let packageName = null
-  try {
-    const packageInfo = await execWithOutput('npm', ['view', '--json'])
-    packageName = packageInfo ? JSON.parse(packageInfo).name : null
-  } catch (error) {
-    if (!error?.message?.match(/code E404/)) {
-      throw error
-    }
-  }
+const { getPublishedInfo } = require('./packageInfo')
 
-  return packageName
-}
 async function allowNpmPublish(version) {
   // We need to check if the package was already published. This can happen if
   // the action was already executed before, but it failed in its last step
   // (GH release).
 
-  const packageName = await getPackageName()
+  const packageInfo = await getPublishedInfo()
+  const packageName = packageInfo?.name
   // Package has not been published before
   if (!packageName) {
     return true
@@ -45,18 +35,7 @@ async function allowNpmPublish(version) {
 
   return !packageVersionInfo
 }
-/**
- * 
- * @param {
- *  npmToken,
-    opticToken,
-    opticUrl,
-    npmTag,
-    version,
-    provenance: boolean
-    hasAccess: boolean
- * }  
- */
+
 async function publishToNpm({
   npmToken,
   opticToken,

--- a/src/utils/publishToNpm.js
+++ b/src/utils/publishToNpm.js
@@ -19,7 +19,7 @@ async function allowNpmPublish(version) {
   // the action was already executed before, but it failed in its last step
   // (GH release).
 
-  const packageName = getPackageName()
+  const packageName = await getPackageName()
   // Package has not been published before
   if (!packageName) {
     return true
@@ -64,7 +64,7 @@ async function publishToNpm({
   npmTag,
   version,
   provenance,
-  hasAccess,
+  access,
 }) {
   await execWithOutput('npm', [
     'config',
@@ -72,12 +72,14 @@ async function publishToNpm({
     `//registry.npmjs.org/:_authToken=${npmToken}`,
   ])
 
-  const packageName = getPackageName()
-
   const flags = ['--tag', npmTag]
-  // new packages and private packages disable provenance, they need to be public
-  if (!packageName && hasAccess && provenance) {
-    flags.push('--provenance --access public')
+
+  if (access) {
+    flags.push('--access', access)
+  }
+
+  if (provenance) {
+    flags.push('--provenance')
   }
 
   if (await allowNpmPublish(version)) {

--- a/test/notifyIssues.test.js
+++ b/test/notifyIssues.test.js
@@ -29,7 +29,9 @@ function setup() {
     .returns('{ "name": "packageName", "version": "1.0.0"}')
 
   const { notifyIssues } = proxyquire('../src/utils/notifyIssues', {
-    fs: { readFileSync: readFileSyncStub },
+    './packageInfo': proxyquire('../src/utils/packageInfo', {
+      fs: { readFileSync: readFileSyncStub },
+    }),
   })
 
   return { notifyIssues }

--- a/test/packageInfo.test.js
+++ b/test/packageInfo.test.js
@@ -3,33 +3,28 @@ const tap = require('tap')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
-const {
-  getLocalInfo,
-  getPublishedInfo,
-} = require('../src/utils/packageInfo') 
-
+const { getLocalInfo, getPublishedInfo } = require('../src/utils/packageInfo')
 
 const mockPackageInfo = {
   name: 'some-package-name',
   license: 'some-license',
   publishConfig: {
-    access: 'restricted'
-  }
+    access: 'restricted',
+  },
 }
 
-const setupPublished = ({ value = JSON.stringify(mockPackageInfo), error } = {}) => {
+const setupPublished = ({
+  value = JSON.stringify(mockPackageInfo),
+  error,
+} = {}) => {
   const execWithOutputStub = sinon.stub()
   const args = ['npm', ['view', '--json']]
 
   if (value) {
-    execWithOutputStub
-      .withArgs(...args)
-      .returns(value)
+    execWithOutputStub.withArgs(...args).returns(value)
   }
   if (error) {
-    execWithOutputStub
-      .withArgs(...args)
-      .throws(error)
+    execWithOutputStub.withArgs(...args).throws(error)
   }
 
   return proxyquire('../src/utils/packageInfo', {
@@ -44,8 +39,8 @@ const setupLocal = ({ value = JSON.stringify(mockPackageInfo) } = {}) => {
     .returns(value)
 
   return proxyquire('../src/utils/packageInfo', {
-      fs: { readFileSync: readFileSyncStub },
-    })
+    fs: { readFileSync: readFileSyncStub },
+  })
 }
 
 tap.test('getPublishedInfo does not get any info for this package', async t => {
@@ -56,52 +51,64 @@ tap.test('getPublishedInfo does not get any info for this package', async t => {
 
 tap.test('getPublishedInfo parses any valid JSON it finds', async t => {
   const mocks = setupPublished()
-  
+
   const packageInfo = await mocks.getPublishedInfo()
   t.match(packageInfo, mockPackageInfo)
 })
 
-tap.test('getPublishedInfo continues and returns null if the request 404s', async t => {
-  const mocks = setupPublished({
-    value: JSON.stringify(mockPackageInfo),
-    error: new Error('code E404 - package not found')
-  })
-  
-  const packageInfo = await mocks.getPublishedInfo()
-  t.match(packageInfo, null)
-})
+tap.test(
+  'getPublishedInfo continues and returns null if the request 404s',
+  async t => {
+    const mocks = setupPublished({
+      value: JSON.stringify(mockPackageInfo),
+      error: new Error('code E404 - package not found'),
+    })
 
-tap.test('getPublishedInfo throws if it encounters an internal error', async t => {
-  const mocks = setupPublished({
-    value: "[{ 'this:' is not ] valid}j.s.o.n()",
-  })
+    const packageInfo = await mocks.getPublishedInfo()
+    t.match(packageInfo, null)
+  }
+)
 
-  t.rejects(mocks.getPublishedInfo, /JSON/)
-})
+tap.test(
+  'getPublishedInfo throws if it encounters an internal error',
+  async t => {
+    const mocks = setupPublished({
+      value: "[{ 'this:' is not ] valid}j.s.o.n()",
+    })
 
-tap.test('getPublishedInfo continues and returns null if the request returns null', async t => {
-  const mocks = setupPublished({
-    value: null,
-  })
-  
-  const packageInfo = await mocks.getPublishedInfo()
-  t.match(packageInfo, null)
-})
+    t.rejects(mocks.getPublishedInfo, /JSON/)
+  }
+)
+
+tap.test(
+  'getPublishedInfo continues and returns null if the request returns null',
+  async t => {
+    const mocks = setupPublished({
+      value: null,
+    })
+
+    const packageInfo = await mocks.getPublishedInfo()
+    t.match(packageInfo, null)
+  }
+)
 
 tap.test('getPublishedInfo throws if it hits a non-404 error', async t => {
   const mocks = setupPublished({
-    error: new Error('code E418 - unexpected teapot')
+    error: new Error('code E418 - unexpected teapot'),
   })
 
   t.rejects(mocks.getPublishedInfo, /teapot/)
 })
 
-tap.test('getLocalInfo gets real name and stable properties of this package', async t => {
-  const packageInfo = getLocalInfo()
-  // Check it works for real using real package.json properties that are stable
-  t.equal(packageInfo.name, 'optic-release-automation-action')
-  t.equal(packageInfo.license, 'MIT')
-})
+tap.test(
+  'getLocalInfo gets real name and stable properties of this package',
+  async t => {
+    const packageInfo = getLocalInfo()
+    // Check it works for real using real package.json properties that are stable
+    t.equal(packageInfo.name, 'optic-release-automation-action')
+    t.equal(packageInfo.license, 'MIT')
+  }
+)
 
 tap.test('getLocalInfo gets data from stringified JSON from file', async t => {
   const mocks = setupLocal()

--- a/test/packageInfo.test.js
+++ b/test/packageInfo.test.js
@@ -1,0 +1,110 @@
+'use strict'
+const tap = require('tap')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+
+const {
+  getLocalInfo,
+  getPublishedInfo,
+} = require('../src/utils/packageInfo') 
+
+
+const mockPackageInfo = {
+  name: 'some-package-name',
+  license: 'some-license',
+  publishConfig: {
+    access: 'restricted'
+  }
+}
+
+const setupPublished = ({ value = JSON.stringify(mockPackageInfo), error } = {}) => {
+  const execWithOutputStub = sinon.stub()
+  const args = ['npm', ['view', '--json']]
+
+  if (value) {
+    execWithOutputStub
+      .withArgs(...args)
+      .returns(value)
+  }
+  if (error) {
+    execWithOutputStub
+      .withArgs(...args)
+      .throws(error)
+  }
+
+  return proxyquire('../src/utils/packageInfo', {
+    './execWithOutput': { execWithOutput: execWithOutputStub },
+  })
+}
+
+const setupLocal = ({ value = JSON.stringify(mockPackageInfo) } = {}) => {
+  const readFileSyncStub = sinon
+    .stub()
+    .withArgs('./package.json', 'utf8')
+    .returns(value)
+
+  return proxyquire('../src/utils/packageInfo', {
+      fs: { readFileSync: readFileSyncStub },
+    })
+}
+
+tap.test('getPublishedInfo does not get any info for this package', async t => {
+  // Check it works for real: this package is a Github Action, not published on NPM, so expect null
+  const packageInfo = await getPublishedInfo()
+  t.notOk(packageInfo)
+})
+
+tap.test('getPublishedInfo parses any valid JSON it finds', async t => {
+  const mocks = setupPublished()
+  
+  const packageInfo = await mocks.getPublishedInfo()
+  t.match(packageInfo, mockPackageInfo)
+})
+
+tap.test('getPublishedInfo continues and returns null if the request 404s', async t => {
+  const mocks = setupPublished({
+    value: JSON.stringify(mockPackageInfo),
+    error: new Error('code E404 - package not found')
+  })
+  
+  const packageInfo = await mocks.getPublishedInfo()
+  t.match(packageInfo, null)
+})
+
+tap.test('getPublishedInfo throws if it encounters an internal error', async t => {
+  const mocks = setupPublished({
+    value: "[{ 'this:' is not ] valid}j.s.o.n()",
+  })
+
+  t.rejects(mocks.getPublishedInfo, /JSON/)
+})
+
+tap.test('getPublishedInfo continues and returns null if the request returns null', async t => {
+  const mocks = setupPublished({
+    value: null,
+  })
+  
+  const packageInfo = await mocks.getPublishedInfo()
+  t.match(packageInfo, null)
+})
+
+tap.test('getPublishedInfo throws if it hits a non-404 error', async t => {
+  const mocks = setupPublished({
+    error: new Error('code E418 - unexpected teapot')
+  })
+
+  t.rejects(mocks.getPublishedInfo, /teapot/)
+})
+
+tap.test('getLocalInfo gets real name and stable properties of this package', async t => {
+  const packageInfo = getLocalInfo()
+  // Check it works for real using real package.json properties that are stable
+  t.equal(packageInfo.name, 'optic-release-automation-action')
+  t.equal(packageInfo.license, 'MIT')
+})
+
+tap.test('getLocalInfo gets data from stringified JSON from file', async t => {
+  const mocks = setupLocal()
+  const packageInfo = mocks.getLocalInfo()
+  t.match(packageInfo, mockPackageInfo)
+})

--- a/test/packageInfo.test.js
+++ b/test/packageInfo.test.js
@@ -76,7 +76,7 @@ tap.test(
       value: "[{ 'this:' is not ] valid}j.s.o.n()",
     })
 
-    t.rejects(mocks.getPublishedInfo, /JSON/)
+    await t.rejects(mocks.getPublishedInfo, /JSON/)
   }
 )
 
@@ -97,7 +97,7 @@ tap.test('getPublishedInfo throws if it hits a non-404 error', async t => {
     error: new Error('code E418 - unexpected teapot'),
   })
 
-  t.rejects(mocks.getPublishedInfo, /teapot/)
+  await t.rejects(mocks.getPublishedInfo, /teapot/)
 })
 
 tap.test(

--- a/test/provenance.test.js
+++ b/test/provenance.test.js
@@ -7,7 +7,6 @@ const {
   checkIsSupported,
   checkPermissions,
   checkProvenanceViability,
-  checkAccessViability,
   getNpmVersion,
 } = require('../src/utils/provenance')
 
@@ -80,16 +79,6 @@ tap.test(
     t.throws(
       () => checkProvenanceViability(),
       'Current npm version not provided'
-    )
-  }
-)
-
-tap.test(
-  'checkProvenanceViability fails fast if NPM package access is private',
-  async t => {
-    t.throws(
-      () => checkAccessViability(),
-      "Can't generate provenance for new or private package, you must set access to public"
     )
   }
 )

--- a/test/provenance.test.js
+++ b/test/provenance.test.js
@@ -3,11 +3,13 @@
 const tap = require('tap')
 const semver = require('semver')
 const sinon = require('sinon')
+const proxyquire = require('proxyquire')
 const {
   checkIsSupported,
   checkPermissions,
-  checkProvenanceViability,
+  ensureProvenanceViability,
   getNpmVersion,
+  // getAccessAdjustment needs proxyquire to mock internal package.json getter results
 } = require('../src/utils/provenance')
 
 const MINIMUM_VERSION = '9.5.0'
@@ -73,11 +75,63 @@ tap.test('checkPermissions passes on minimum version with env', async t => {
   t.doesNotThrow(() => checkIsSupported(MINIMUM_VERSION))
 })
 
+const setupAccessAdjustment = ({ local, published }) => {
+  const { getAccessAdjustment } = proxyquire('../src/utils/provenance', {
+    './packageInfo': {
+      getPublishedInfo: async () => published,
+      getLocalInfo: () => local,
+    }
+  })
+  return getAccessAdjustment
+}
+const unscopedPackageName = 'unscoped-fake-package'
+const scopedPackageName = '@scoped/fake-package'
+
+tap.test('getAccessAdjustment returns { access: public } if unscoped, unpublished and no access option', async t => {
+  const getAccessAdjustment = setupAccessAdjustment({
+    local: { name: unscopedPackageName },
+    published: null
+  })
+  t.match(await getAccessAdjustment(), { access: 'public' })
+})
+
+tap.test('getAccessAdjustment does nothing if passed defined access option', async t => {
+  const getAccessAdjustment = setupAccessAdjustment({
+    local: { name: unscopedPackageName },
+    published: null
+  })
+  t.notOk(await getAccessAdjustment({ access: 'public' }))
+})
+
+tap.test('getAccessAdjustment does nothing if package.json defines access', async t => {
+  const getAccessAdjustment = setupAccessAdjustment({
+    local: { name: unscopedPackageName, publishConfig: { access: 'public '} },
+    published: null
+  })
+  t.notOk(await getAccessAdjustment())
+})
+
+tap.test('getAccessAdjustment does nothing if package.json name is scoped', async t => {
+  const getAccessAdjustment = setupAccessAdjustment({
+    local: { name: scopedPackageName },
+    published: null
+  })
+  t.notOk(await getAccessAdjustment())
+})
+
+tap.test('getAccessAdjustment does nothing if package is on npm', async t => {
+  const getAccessAdjustment = setupAccessAdjustment({
+    local: { name: unscopedPackageName },
+    published: { name: unscopedPackageName }
+  })
+  t.notOk(await getAccessAdjustment())
+})
+
 tap.test(
-  'checkProvenanceViability fails fast if NPM version unavailable',
+  'ensureProvenanceViability fails fast if NPM version unavailable',
   async t => {
-    t.throws(
-      () => checkProvenanceViability(),
+    t.rejects(
+      () => ensureProvenanceViability(),
       'Current npm version not provided'
     )
   }

--- a/test/provenance.test.js
+++ b/test/provenance.test.js
@@ -80,49 +80,64 @@ const setupAccessAdjustment = ({ local, published }) => {
     './packageInfo': {
       getPublishedInfo: async () => published,
       getLocalInfo: () => local,
-    }
+    },
   })
   return getAccessAdjustment
 }
 const unscopedPackageName = 'unscoped-fake-package'
 const scopedPackageName = '@scoped/fake-package'
 
-tap.test('getAccessAdjustment returns { access: public } if unscoped, unpublished and no access option', async t => {
-  const getAccessAdjustment = setupAccessAdjustment({
-    local: { name: unscopedPackageName },
-    published: null
-  })
-  t.match(await getAccessAdjustment(), { access: 'public' })
-})
+tap.test(
+  'getAccessAdjustment returns { access: public } if unscoped, unpublished and no access option',
+  async t => {
+    const getAccessAdjustment = setupAccessAdjustment({
+      local: { name: unscopedPackageName },
+      published: null,
+    })
+    t.match(await getAccessAdjustment(), { access: 'public' })
+  }
+)
 
-tap.test('getAccessAdjustment does nothing if passed defined access option', async t => {
-  const getAccessAdjustment = setupAccessAdjustment({
-    local: { name: unscopedPackageName },
-    published: null
-  })
-  t.notOk(await getAccessAdjustment({ access: 'public' }))
-})
+tap.test(
+  'getAccessAdjustment does nothing if passed defined access option',
+  async t => {
+    const getAccessAdjustment = setupAccessAdjustment({
+      local: { name: unscopedPackageName },
+      published: null,
+    })
+    t.notOk(await getAccessAdjustment({ access: 'public' }))
+  }
+)
 
-tap.test('getAccessAdjustment does nothing if package.json defines access', async t => {
-  const getAccessAdjustment = setupAccessAdjustment({
-    local: { name: unscopedPackageName, publishConfig: { access: 'public '} },
-    published: null
-  })
-  t.notOk(await getAccessAdjustment())
-})
+tap.test(
+  'getAccessAdjustment does nothing if package.json defines access',
+  async t => {
+    const getAccessAdjustment = setupAccessAdjustment({
+      local: {
+        name: unscopedPackageName,
+        publishConfig: { access: 'public ' },
+      },
+      published: null,
+    })
+    t.notOk(await getAccessAdjustment())
+  }
+)
 
-tap.test('getAccessAdjustment does nothing if package.json name is scoped', async t => {
-  const getAccessAdjustment = setupAccessAdjustment({
-    local: { name: scopedPackageName },
-    published: null
-  })
-  t.notOk(await getAccessAdjustment())
-})
+tap.test(
+  'getAccessAdjustment does nothing if package.json name is scoped',
+  async t => {
+    const getAccessAdjustment = setupAccessAdjustment({
+      local: { name: scopedPackageName },
+      published: null,
+    })
+    t.notOk(await getAccessAdjustment())
+  }
+)
 
 tap.test('getAccessAdjustment does nothing if package is on npm', async t => {
   const getAccessAdjustment = setupAccessAdjustment({
     local: { name: unscopedPackageName },
-    published: { name: unscopedPackageName }
+    published: { name: unscopedPackageName },
   })
   t.notOk(await getAccessAdjustment())
 })

--- a/test/provenance.test.js
+++ b/test/provenance.test.js
@@ -144,10 +144,6 @@ tap.test('getAccessAdjustment does nothing if package is on npm', async t => {
 
 tap.test(
   'ensureProvenanceViability fails fast if NPM version unavailable',
-  async t => {
-    t.rejects(
-      () => ensureProvenanceViability(),
-      'Current npm version not provided'
-    )
-  }
+  async t =>
+    t.rejects(ensureProvenanceViability, 'Current npm version not provided')
 )

--- a/test/provenance.test.js
+++ b/test/provenance.test.js
@@ -89,7 +89,7 @@ tap.test(
   async t => {
     t.throws(
       () => checkAccessViability(),
-      'Can\'t generate provenance for new or private package, you must set access to public'
+      "Can't generate provenance for new or private package, you must set access to public"
     )
   }
 )

--- a/test/provenance.test.js
+++ b/test/provenance.test.js
@@ -5,9 +5,9 @@ const semver = require('semver')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 const {
+  getProvenanceOptions,
   checkIsSupported,
   checkPermissions,
-  ensureProvenanceViability,
   getNpmVersion,
   // getAccessAdjustment needs proxyquire to mock internal package.json getter results
 } = require('../src/utils/provenance')
@@ -143,7 +143,6 @@ tap.test('getAccessAdjustment does nothing if package is on npm', async t => {
 })
 
 tap.test(
-  'ensureProvenanceViability fails fast if NPM version unavailable',
-  async t =>
-    t.rejects(ensureProvenanceViability, 'Current npm version not provided')
+  'getProvenanceOptions fails fast if NPM version unavailable',
+  async t => t.rejects(getProvenanceOptions, 'Current npm version not provided')
 )

--- a/test/provenance.test.js
+++ b/test/provenance.test.js
@@ -7,6 +7,7 @@ const {
   checkIsSupported,
   checkPermissions,
   checkProvenanceViability,
+  checkAccessViability,
   getNpmVersion,
 } = require('../src/utils/provenance')
 
@@ -79,6 +80,16 @@ tap.test(
     t.throws(
       () => checkProvenanceViability(),
       'Current npm version not provided'
+    )
+  }
+)
+
+tap.test(
+  'checkProvenanceViability fails fast if NPM package access is private',
+  async t => {
+    t.throws(
+      () => checkAccessViability(),
+      'Can\'t generate provenance for new or private package, you must set access to public'
     )
   }
 )

--- a/test/publishToNpm.test.js
+++ b/test/publishToNpm.test.js
@@ -301,3 +301,22 @@ tap.test('Adds --provenance flag when provenance option provided', async () => {
     '--provenance',
   ])
 })
+
+tap.test('Adds --access flag if provided as an input', async () => {
+  const { publishToNpmProxy, execWithOutputStub } = setup()
+  await publishToNpmProxy.publishToNpm({
+    npmToken: 'a-token',
+    opticUrl: 'https://optic-test.run.app/api/generate/',
+    npmTag: 'latest',
+    version: 'v5.1.3',
+    access: 'public',
+  })
+
+  sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
+    'publish',
+    '--tag',
+    'latest',
+    '--access',
+    'public',
+  ])
+})

--- a/test/publishToNpm.test.js
+++ b/test/publishToNpm.test.js
@@ -4,7 +4,11 @@ const tap = require('tap')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
-const setup = ({ packageName =  'fakeTestPkg', published = true, mockPackageInfo } = {}) => {
+const setup = ({
+  packageName = 'fakeTestPkg',
+  published = true,
+  mockPackageInfo,
+} = {}) => {
   const execWithOutputStub = sinon.stub()
   execWithOutputStub
     .withArgs('curl', [
@@ -14,17 +18,22 @@ const setup = ({ packageName =  'fakeTestPkg', published = true, mockPackageInfo
     .returns('otp123')
 
   // npm behavior < v8.13.0
-  execWithOutputStub.withArgs('npm', ['view', `${packageName}@v5.1.3`]).returns('')
+  execWithOutputStub
+    .withArgs('npm', ['view', `${packageName}@v5.1.3`])
+    .returns('')
 
   const getLocalInfo = () => ({ name: packageName })
-  const getPublishedInfo = async () => published ? { name: packageName } : null
+  const getPublishedInfo = async () =>
+    published ? { name: packageName } : null
 
   const publishToNpmProxy = proxyquire('../src/utils/publishToNpm', {
     './execWithOutput': { execWithOutput: execWithOutputStub },
-    './packageInfo': mockPackageInfo ? mockPackageInfo({ execWithOutputStub, getLocalInfo, getPublishedInfo}) : {
-      getLocalInfo,
-      getPublishedInfo,
-    }
+    './packageInfo': mockPackageInfo
+      ? mockPackageInfo({ execWithOutputStub, getLocalInfo, getPublishedInfo })
+      : {
+          getLocalInfo,
+          getPublishedInfo,
+        },
   })
 
   return { execWithOutputStub, publishToNpmProxy }
@@ -76,7 +85,9 @@ tap.test('Should publish to npm with optic', async t => {
 tap.test(
   "Should publish to npm when package hasn't been published before",
   async t => {
-    const { publishToNpmProxy, execWithOutputStub } = setup({ published: false })
+    const { publishToNpmProxy, execWithOutputStub } = setup({
+      published: false,
+    })
 
     await publishToNpmProxy.publishToNpm({
       npmToken: 'a-token',
@@ -164,9 +175,9 @@ tap.test('Should stop action if package info retrieval fails', async t => {
     mockPackageInfo: ({ getLocalInfo, execWithOutputStub }) => ({
       getLocalInfo,
       getPublishedInfo: proxyquire('../src/utils/packageInfo', {
-        './execWithOutput': { execWithOutput: execWithOutputStub }
-      }).getPublishedInfo
-    })
+        './execWithOutput': { execWithOutput: execWithOutputStub },
+      }).getPublishedInfo,
+    }),
   })
   execWithOutputStub
     .withArgs('npm', ['view', '--json'])
@@ -182,7 +193,7 @@ tap.test('Should stop action if package info retrieval fails', async t => {
   } catch (e) {
     t.equal(e.message, 'Network Error')
   }
-  
+
   sinon.assert.neverCalledWith(execWithOutputStub, 'npm', [
     'publish',
     '--otp',
@@ -247,9 +258,9 @@ tap.test(
       mockPackageInfo: ({ getLocalInfo, execWithOutputStub }) => ({
         getLocalInfo,
         getPublishedInfo: proxyquire('../src/utils/packageInfo', {
-          './execWithOutput': { execWithOutput: execWithOutputStub }
-        }).getPublishedInfo
-      })
+          './execWithOutput': { execWithOutput: execWithOutputStub },
+        }).getPublishedInfo,
+      }),
     })
 
     execWithOutputStub
@@ -323,8 +334,8 @@ tap.test('Adds --provenance flag when provenance option provided', async t => {
     provenance: true,
   })
 
-  t.doesNotThrow(
-    () => sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
+  t.doesNotThrow(() =>
+    sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
       'publish',
       '--tag',
       'latest',
@@ -343,8 +354,8 @@ tap.test('Adds --access flag if provided as an input', async t => {
     access: 'public',
   })
 
-  t.doesNotThrow(
-    () => sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
+  t.doesNotThrow(() =>
+    sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
       'publish',
       '--tag',
       'latest',

--- a/test/publishToNpm.test.js
+++ b/test/publishToNpm.test.js
@@ -324,7 +324,7 @@ tap.test(
   }
 )
 
-tap.test('Adds --provenance flag when provenance option provided', async t => {
+tap.test('Adds --provenance flag when provenance option provided', async () => {
   const { publishToNpmProxy, execWithOutputStub } = setup()
   await publishToNpmProxy.publishToNpm({
     npmToken: 'a-token',
@@ -334,17 +334,15 @@ tap.test('Adds --provenance flag when provenance option provided', async t => {
     provenance: true,
   })
 
-  t.doesNotThrow(() =>
-    sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
-      'publish',
-      '--tag',
-      'latest',
-      '--provenance',
-    ])
-  )
+  sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
+    'publish',
+    '--tag',
+    'latest',
+    '--provenance',
+  ])
 })
 
-tap.test('Adds --access flag if provided as an input', async t => {
+tap.test('Adds --access flag if provided as an input', async () => {
   const { publishToNpmProxy, execWithOutputStub } = setup()
   await publishToNpmProxy.publishToNpm({
     npmToken: 'a-token',
@@ -354,13 +352,11 @@ tap.test('Adds --access flag if provided as an input', async t => {
     access: 'public',
   })
 
-  t.doesNotThrow(() =>
-    sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
-      'publish',
-      '--tag',
-      'latest',
-      '--access',
-      'public',
-    ])
-  )
+  sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
+    'publish',
+    '--tag',
+    'latest',
+    '--access',
+    'public',
+  ])
 })

--- a/test/publishToNpm.test.js
+++ b/test/publishToNpm.test.js
@@ -4,7 +4,7 @@ const tap = require('tap')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
-const setup = () => {
+const setup = ({ packageName =  'fakeTestPkg', published = true, mockPackageInfo } = {}) => {
   const execWithOutputStub = sinon.stub()
   execWithOutputStub
     .withArgs('curl', [
@@ -12,15 +12,19 @@ const setup = () => {
       'https://optic-test.run.app/api/generate/optic-token',
     ])
     .returns('otp123')
-  execWithOutputStub
-    .withArgs('npm', ['view', '--json'])
-    .returns('{"name":"fakeTestPkg"}')
 
   // npm behavior < v8.13.0
-  execWithOutputStub.withArgs('npm', ['view', 'fakeTestPkg@v5.1.3']).returns('')
+  execWithOutputStub.withArgs('npm', ['view', `${packageName}@v5.1.3`]).returns('')
+
+  const getLocalInfo = () => ({ name: packageName })
+  const getPublishedInfo = async () => published ? { name: packageName } : null
 
   const publishToNpmProxy = proxyquire('../src/utils/publishToNpm', {
     './execWithOutput': { execWithOutput: execWithOutputStub },
+    './packageInfo': mockPackageInfo ? mockPackageInfo({ execWithOutputStub, getLocalInfo, getPublishedInfo}) : {
+      getLocalInfo,
+      getPublishedInfo,
+    }
   })
 
   return { execWithOutputStub, publishToNpmProxy }
@@ -47,22 +51,19 @@ tap.test('Should publish to npm with optic', async t => {
   ])
   t.pass('npm config')
 
-  // We skip calls in these checks:
-  // - 1 used to get the package name
-  // - 2 used to check if the package version is already published
-  sinon.assert.calledWithExactly(execWithOutputStub.getCall(3), 'npm', [
+  sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
     'pack',
     '--dry-run',
   ])
   t.pass('npm pack called')
 
-  sinon.assert.calledWithExactly(execWithOutputStub.getCall(4), 'curl', [
+  sinon.assert.calledWithExactly(execWithOutputStub, 'curl', [
     '-s',
     'https://optic-test.run.app/api/generate/optic-token',
   ])
   t.pass('curl called')
 
-  sinon.assert.calledWithExactly(execWithOutputStub.getCall(5), 'npm', [
+  sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
     'publish',
     '--otp',
     'otp123',
@@ -74,10 +75,8 @@ tap.test('Should publish to npm with optic', async t => {
 
 tap.test(
   "Should publish to npm when package hasn't been published before",
-  async () => {
-    const { publishToNpmProxy, execWithOutputStub } = setup()
-
-    execWithOutputStub.withArgs('npm', ['view', '--json']).resolves('')
+  async t => {
+    const { publishToNpmProxy, execWithOutputStub } = setup({ published: false })
 
     await publishToNpmProxy.publishToNpm({
       npmToken: 'a-token',
@@ -90,15 +89,18 @@ tap.test(
       'pack',
       '--dry-run',
     ])
+    t.pass('npm pack called')
+
     sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
       'publish',
       '--tag',
       'latest',
     ])
+    t.pass('npm publish called')
   }
 )
 
-tap.test('Should publish to npm without optic', async () => {
+tap.test('Should publish to npm without optic', async t => {
   const { publishToNpmProxy, execWithOutputStub } = setup()
   await publishToNpmProxy.publishToNpm({
     npmToken: 'a-token',
@@ -111,16 +113,19 @@ tap.test('Should publish to npm without optic', async () => {
     'pack',
     '--dry-run',
   ])
+  t.pass('npm pack called')
+
   sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
     'publish',
     '--tag',
     'latest',
   ])
+  t.pass('npm publish called')
 })
 
 tap.test(
   'Should skip npm package publication when it was already published',
-  async () => {
+  async t => {
     const { publishToNpmProxy, execWithOutputStub } = setup()
 
     execWithOutputStub
@@ -141,18 +146,28 @@ tap.test(
       '--tag',
       'latest',
     ])
+    t.pass('publish never called with otp')
+
     sinon.assert.neverCalledWith(execWithOutputStub, 'npm', [
       'publish',
       '--tag',
       'latest',
     ])
+    t.pass('publish never called')
   }
 )
 
 tap.test('Should stop action if package info retrieval fails', async t => {
   t.plan(3)
-  const { publishToNpmProxy, execWithOutputStub } = setup()
-
+  const { publishToNpmProxy, execWithOutputStub } = setup({
+    // Use original getPublishedInfo logic with execWithOutputStub injected into it
+    mockPackageInfo: ({ getLocalInfo, execWithOutputStub }) => ({
+      getLocalInfo,
+      getPublishedInfo: proxyquire('../src/utils/packageInfo', {
+        './execWithOutput': { execWithOutput: execWithOutputStub }
+      }).getPublishedInfo
+    })
+  })
   execWithOutputStub
     .withArgs('npm', ['view', '--json'])
     .throws(new Error('Network Error'))
@@ -167,7 +182,7 @@ tap.test('Should stop action if package info retrieval fails', async t => {
   } catch (e) {
     t.equal(e.message, 'Network Error')
   }
-
+  
   sinon.assert.neverCalledWith(execWithOutputStub, 'npm', [
     'publish',
     '--otp',
@@ -226,8 +241,16 @@ tap.test(
 
 tap.test(
   'Should continue action if package info returns not found',
-  async () => {
-    const { publishToNpmProxy, execWithOutputStub } = setup()
+  async t => {
+    const { publishToNpmProxy, execWithOutputStub } = setup({
+      // Use original getPublishedInfo logic with execWithOutputStub injected into it
+      mockPackageInfo: ({ getLocalInfo, execWithOutputStub }) => ({
+        getLocalInfo,
+        getPublishedInfo: proxyquire('../src/utils/packageInfo', {
+          './execWithOutput': { execWithOutput: execWithOutputStub }
+        }).getPublishedInfo
+      })
+    })
 
     execWithOutputStub
       .withArgs('npm', ['view', '--json'])
@@ -248,17 +271,20 @@ tap.test(
       'pack',
       '--dry-run',
     ])
+    t.pass('npm pack called')
+
     sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
       'publish',
       '--tag',
       'latest',
     ])
+    t.pass('npm publish called')
   }
 )
 
 tap.test(
   'Should continue action if package version info returns not found',
-  async () => {
+  async t => {
     const { publishToNpmProxy, execWithOutputStub } = setup()
 
     execWithOutputStub
@@ -276,15 +302,18 @@ tap.test(
       'pack',
       '--dry-run',
     ])
+    t.pass('npm pack called')
+
     sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
       'publish',
       '--tag',
       'latest',
     ])
+    t.pass('npm publish called')
   }
 )
 
-tap.test('Adds --provenance flag when provenance option provided', async () => {
+tap.test('Adds --provenance flag when provenance option provided', async t => {
   const { publishToNpmProxy, execWithOutputStub } = setup()
   await publishToNpmProxy.publishToNpm({
     npmToken: 'a-token',
@@ -294,15 +323,17 @@ tap.test('Adds --provenance flag when provenance option provided', async () => {
     provenance: true,
   })
 
-  sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
-    'publish',
-    '--tag',
-    'latest',
-    '--provenance',
-  ])
+  t.doesNotThrow(
+    () => sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
+      'publish',
+      '--tag',
+      'latest',
+      '--provenance',
+    ])
+  )
 })
 
-tap.test('Adds --access flag if provided as an input', async () => {
+tap.test('Adds --access flag if provided as an input', async t => {
   const { publishToNpmProxy, execWithOutputStub } = setup()
   await publishToNpmProxy.publishToNpm({
     npmToken: 'a-token',
@@ -312,11 +343,13 @@ tap.test('Adds --access flag if provided as an input', async () => {
     access: 'public',
   })
 
-  sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
-    'publish',
-    '--tag',
-    'latest',
-    '--access',
-    'public',
-  ])
+  t.doesNotThrow(
+    () => sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [
+      'publish',
+      '--tag',
+      'latest',
+      '--access',
+      'public',
+    ])
+  )
 })

--- a/test/release.test.js
+++ b/test/release.test.js
@@ -283,6 +283,75 @@ tap.test('Aborts publish with provenance if missing permission', async () => {
   )
 })
 
+tap.test(
+  'Should publish with --access public if flag set',
+  async () => {
+    const { release, stubs } = setup()
+    await release({
+      ...DEFAULT_ACTION_DATA,
+      inputs: {
+        'app-name': APP_NAME,
+        'npm-token': 'a-token',
+        access: 'public',
+      },
+    })
+
+    sinon.assert.notCalled(stubs.coreStub.setFailed)
+    sinon.assert.calledWithMatch(stubs.publishToNpmStub, {
+      npmToken: 'a-token',
+      opticUrl: 'https://optic-test.run.app/api/generate/',
+      npmTag: 'latest',
+      access: 'public',
+    })
+  }
+)
+
+tap.test(
+  'Should publish with --access restricted if flag set',
+  async () => {
+    const { release, stubs } = setup()
+    await release({
+      ...DEFAULT_ACTION_DATA,
+      inputs: {
+        'app-name': APP_NAME,
+        'npm-token': 'a-token',
+        access: 'restricted',
+      },
+    })
+
+    sinon.assert.notCalled(stubs.coreStub.setFailed)
+    sinon.assert.calledWithMatch(stubs.publishToNpmStub, {
+      npmToken: 'a-token',
+      opticUrl: 'https://optic-test.run.app/api/generate/',
+      npmTag: 'latest',
+      access: 'restricted',
+    })
+  }
+)
+
+tap.test(
+  'Should disallow unsupported --access flag',
+  async () => {
+    const { release, stubs } = setup()
+
+    const invalidString = 'public; node -e "throw new Error(`arbitrary command executed`)"'
+
+    await release({
+      ...DEFAULT_ACTION_DATA,
+      inputs: {
+        'app-name': APP_NAME,
+        'npm-token': 'a-token',
+        access: invalidString,
+      },
+    })
+
+    sinon.assert.calledWithMatch(
+      stubs.coreStub.setFailed,
+      `Invalid "access" option provided ("${invalidString}"), should be one of "public", "restricted"`
+    )
+  }
+)
+
 tap.test('Should not publish to npm if there is no npm token', async () => {
   const { release, stubs } = setup()
   stubs.callApiStub.throws()

--- a/test/release.test.js
+++ b/test/release.test.js
@@ -66,7 +66,7 @@ const DEFAULT_ACTION_DATA = {
 /**
  * @param {{ npmVersion: string | undefined, env: Record<string, string> | undefined }} [options]
  */
-function setup({ npmVersion, env } = {}) {
+function setup({ npmVersion, env, isPublished = true, isScoped = true } = {}) {
   if (env) {
     // Add any test-specific environment variables. They get cleaned up by tap.afterEach(sinon.restore).
     Object.entries(env).forEach(([key, value]) => {
@@ -92,6 +92,15 @@ function setup({ npmVersion, env } = {}) {
   const publishToNpmStub = sinon.stub(publishToNpmAction, 'publishToNpm')
   const notifyIssuesStub = sinon.stub(notifyIssuesAction, 'notifyIssues')
 
+  const packageName = isScoped ? '@some/package-name' : 'some-package-name'
+  const provenanceProxy = proxyquire('../src/utils/provenance', {
+    './packageInfo': {
+      getLocalInfo: () => ({ name: packageName }),
+      getPublishedInfo: async () => isPublished ? { name: packageName } : null
+    }
+  })
+  if (npmVersion) provenanceProxy.getNpmVersion = () => npmVersion
+
   const callApiStub = sinon
     .stub(callApiAction, 'callApi')
     .resolves({ data: { body: 'test_body', html_url: 'test_url' } })
@@ -102,11 +111,8 @@ function setup({ npmVersion, env } = {}) {
     './utils/revertCommit': revertCommitStub,
     './utils/publishToNpm': publishToNpmStub,
     './utils/notifyIssues': notifyIssuesStub,
+    './utils/provenance': provenanceProxy,
     '@actions/core': coreStub,
-  }
-
-  if (npmVersion) {
-    proxyStubs['./utils/provenance'] = { getNpmVersion: () => npmVersion }
   }
 
   const release = proxyquire('../src/release', proxyStubs)
@@ -218,7 +224,7 @@ tap.test('Should publish to npm without optic', async () => {
 
 tap.test(
   'Should publish with provenance if flag set and conditions met',
-  async () => {
+  async t => {
     const { release, stubs } = setup({
       npmVersion: '9.5.0', // valid
       env: { ACTIONS_ID_TOKEN_REQUEST_URL: 'https://example.com' }, // valid
@@ -233,16 +239,19 @@ tap.test(
     })
 
     sinon.assert.notCalled(stubs.coreStub.setFailed)
+    t.pass('not failed')
+
     sinon.assert.calledWithMatch(stubs.publishToNpmStub, {
       npmToken: 'a-token',
       opticUrl: 'https://optic-test.run.app/api/generate/',
       npmTag: 'latest',
       provenance: true,
     })
+    t.pass('publish called')
   }
 )
 
-tap.test('Aborts publish with provenance if NPM version too old', async () => {
+tap.test('Aborts publish with provenance if NPM version too old', async t => {
   const { release, stubs } = setup({
     npmVersion: '9.4.0', // too old (is before 9.5.0)
     env: { ACTIONS_ID_TOKEN_REQUEST_URL: 'https://example.com' }, // valid
@@ -261,9 +270,10 @@ tap.test('Aborts publish with provenance if NPM version too old', async () => {
     stubs.coreStub.setFailed,
     'Provenance requires NPM >=9.5.0, but this action is using v9.4.0'
   )
+  t.pass('did set failed')
 })
 
-tap.test('Aborts publish with provenance if missing permission', async () => {
+tap.test('Aborts publish with provenance if missing permission', async t => {
   const { release, stubs } = setup({
     npmVersion: '9.5.0', // valid, but before missing var is correctly handled on NPM's side (9.6.1)
     // missing ACTIONS_ID_TOKEN_REQUEST_URL which is set from `id-token: write` permission.
@@ -277,15 +287,17 @@ tap.test('Aborts publish with provenance if missing permission', async () => {
       provenance: 'true',
     },
   })
+
   sinon.assert.calledWithMatch(
     stubs.coreStub.setFailed,
     'Provenance generation in GitHub Actions requires "write" access to the "id-token" permission'
   )
+  t.pass('did set failed')
 })
 
 tap.test(
   'Should publish with --access public if flag set',
-  async () => {
+  async t => {
     const { release, stubs } = setup()
     await release({
       ...DEFAULT_ACTION_DATA,
@@ -297,18 +309,21 @@ tap.test(
     })
 
     sinon.assert.notCalled(stubs.coreStub.setFailed)
+    t.pass('did not set failed')
+
     sinon.assert.calledWithMatch(stubs.publishToNpmStub, {
       npmToken: 'a-token',
       opticUrl: 'https://optic-test.run.app/api/generate/',
       npmTag: 'latest',
       access: 'public',
     })
+    t.pass('called publishToNpm')
   }
 )
 
 tap.test(
   'Should publish with --access restricted if flag set',
-  async () => {
+  async t => {
     const { release, stubs } = setup()
     await release({
       ...DEFAULT_ACTION_DATA,
@@ -320,18 +335,21 @@ tap.test(
     })
 
     sinon.assert.notCalled(stubs.coreStub.setFailed)
+    t.pass('did not set failed')
+
     sinon.assert.calledWithMatch(stubs.publishToNpmStub, {
       npmToken: 'a-token',
       opticUrl: 'https://optic-test.run.app/api/generate/',
       npmTag: 'latest',
       access: 'restricted',
     })
+    t.pass('called publishToNpm')
   }
 )
 
 tap.test(
   'Should disallow unsupported --access flag',
-  async () => {
+  async t => {
     const { release, stubs } = setup()
 
     const invalidString = 'public; node -e "throw new Error(`arbitrary command executed`)"'
@@ -349,6 +367,114 @@ tap.test(
       stubs.coreStub.setFailed,
       `Invalid "access" option provided ("${invalidString}"), should be one of "public", "restricted"`
     )
+    t.pass('did set failed')
+  }
+)
+
+tap.test(
+  'Should publish with --access public and provenance if unscoped and unpublished',
+  async t => {
+    const { release, stubs } = setup({ isScoped: false, isPublished: false })
+    await release({
+      ...DEFAULT_ACTION_DATA,
+      inputs: {
+        'app-name': APP_NAME,
+        'npm-token': 'a-token',
+        provenance: true,
+      },
+    })
+
+    sinon.assert.notCalled(stubs.coreStub.setFailed)
+    t.pass('did not set failed')
+
+    sinon.assert.calledWithMatch(stubs.publishToNpmStub, {
+      npmToken: 'a-token',
+      opticUrl: 'https://optic-test.run.app/api/generate/',
+      npmTag: 'latest',
+      access: 'public',
+      provenance: true,
+    })
+    t.pass('called publishToNpm')
+  }
+)
+
+tap.test(
+  'Should not override access restricted with provenance while unscoped and unpublished',
+  async t => {
+    const { release, stubs } = setup({ isScoped: false, isPublished: false })
+    await release({
+      ...DEFAULT_ACTION_DATA,
+      inputs: {
+        'app-name': APP_NAME,
+        'npm-token': 'a-token',
+        provenance: true,
+        access: 'restricted',
+      },
+    })
+
+    sinon.assert.notCalled(stubs.coreStub.setFailed)
+    t.pass('did not set failed')
+
+    sinon.assert.calledWithMatch(stubs.publishToNpmStub, {
+      npmToken: 'a-token',
+      opticUrl: 'https://optic-test.run.app/api/generate/',
+      npmTag: 'latest',
+      access: 'restricted',
+      provenance: true,
+    })
+    t.pass('called publishToNpm')
+  }
+)
+
+tap.test(
+  'Should publish with provenance and not add access when scoped and unpublished',
+  async t => {
+    const { release, stubs } = setup({ isScoped: true, isPublished: false })
+    await release({
+      ...DEFAULT_ACTION_DATA,
+      inputs: {
+        'app-name': APP_NAME,
+        'npm-token': 'a-token',
+        provenance: true,
+      },
+    })
+
+    sinon.assert.notCalled(stubs.coreStub.setFailed)
+    t.pass('did not set failed')
+
+    sinon.assert.calledWithMatch(stubs.publishToNpmStub, {
+      npmToken: 'a-token',
+      opticUrl: 'https://optic-test.run.app/api/generate/',
+      npmTag: 'latest',
+      provenance: true,
+    })
+    t.pass('called publishToNpm')
+  }
+)
+
+tap.test(
+  'Should publish with provenance and not add access when unscoped and published',
+  async t => {
+    const { release, stubs } = setup({ isScoped: false, isPublished: true })
+    await release({
+      ...DEFAULT_ACTION_DATA,
+      inputs: {
+        'app-name': APP_NAME,
+        'npm-token': 'a-token',
+        provenance: true,
+      },
+    })
+
+    sinon.assert.notCalled(stubs.coreStub.setFailed)
+    t.pass('did not set failed')
+
+    sinon.assert.calledWithMatch(stubs.publishToNpmStub, {
+      npmToken: 'a-token',
+      opticUrl: 'https://optic-test.run.app/api/generate/',
+      npmTag: 'latest',
+      provenance: true,
+    })
+    t.pass('called publishToNpm')
   }
 )
 

--- a/test/release.test.js
+++ b/test/release.test.js
@@ -367,7 +367,12 @@ tap.test('Should disallow unsupported --access flag', async t => {
 tap.test(
   'Should publish with --access public and provenance if unscoped and unpublished',
   async t => {
-    const { release, stubs } = setup({ isScoped: false, isPublished: false })
+    const { release, stubs } = setup({
+      isScoped: false,
+      isPublished: false,
+      npmVersion: '9.5.0', // valid
+      env: { ACTIONS_ID_TOKEN_REQUEST_URL: 'https://example.com' }, // valid
+    })
     await release({
       ...DEFAULT_ACTION_DATA,
       inputs: {
@@ -394,7 +399,13 @@ tap.test(
 tap.test(
   'Should not override access restricted with provenance while unscoped and unpublished',
   async t => {
-    const { release, stubs } = setup({ isScoped: false, isPublished: false })
+    const { release, stubs } = setup({
+      isScoped: false,
+      isPublished: false,
+      npmVersion: '9.5.0', // valid
+      env: { ACTIONS_ID_TOKEN_REQUEST_URL: 'https://example.com' }, // valid
+    })
+
     await release({
       ...DEFAULT_ACTION_DATA,
       inputs: {
@@ -422,7 +433,12 @@ tap.test(
 tap.test(
   'Should publish with provenance and not add access when scoped and unpublished',
   async t => {
-    const { release, stubs } = setup({ isScoped: true, isPublished: false })
+    const { release, stubs } = setup({
+      isScoped: true,
+      isPublished: false,
+      npmVersion: '9.5.0', // valid
+      env: { ACTIONS_ID_TOKEN_REQUEST_URL: 'https://example.com' }, // valid
+    })
     await release({
       ...DEFAULT_ACTION_DATA,
       inputs: {
@@ -448,7 +464,12 @@ tap.test(
 tap.test(
   'Should publish with provenance and not add access when unscoped and published',
   async t => {
-    const { release, stubs } = setup({ isScoped: false, isPublished: true })
+    const { release, stubs } = setup({
+      isScoped: false,
+      isPublished: true,
+      npmVersion: '9.5.0', // valid
+      env: { ACTIONS_ID_TOKEN_REQUEST_URL: 'https://example.com' }, // valid
+    })
     await release({
       ...DEFAULT_ACTION_DATA,
       inputs: {

--- a/test/release.test.js
+++ b/test/release.test.js
@@ -96,8 +96,9 @@ function setup({ npmVersion, env, isPublished = true, isScoped = true } = {}) {
   const provenanceProxy = proxyquire('../src/utils/provenance', {
     './packageInfo': {
       getLocalInfo: () => ({ name: packageName }),
-      getPublishedInfo: async () => isPublished ? { name: packageName } : null
-    }
+      getPublishedInfo: async () =>
+        isPublished ? { name: packageName } : null,
+    },
   })
   if (npmVersion) provenanceProxy.getNpmVersion = () => npmVersion
 
@@ -295,81 +296,73 @@ tap.test('Aborts publish with provenance if missing permission', async t => {
   t.pass('did set failed')
 })
 
-tap.test(
-  'Should publish with --access public if flag set',
-  async t => {
-    const { release, stubs } = setup()
-    await release({
-      ...DEFAULT_ACTION_DATA,
-      inputs: {
-        'app-name': APP_NAME,
-        'npm-token': 'a-token',
-        access: 'public',
-      },
-    })
-
-    sinon.assert.notCalled(stubs.coreStub.setFailed)
-    t.pass('did not set failed')
-
-    sinon.assert.calledWithMatch(stubs.publishToNpmStub, {
-      npmToken: 'a-token',
-      opticUrl: 'https://optic-test.run.app/api/generate/',
-      npmTag: 'latest',
+tap.test('Should publish with --access public if flag set', async t => {
+  const { release, stubs } = setup()
+  await release({
+    ...DEFAULT_ACTION_DATA,
+    inputs: {
+      'app-name': APP_NAME,
+      'npm-token': 'a-token',
       access: 'public',
-    })
-    t.pass('called publishToNpm')
-  }
-)
+    },
+  })
 
-tap.test(
-  'Should publish with --access restricted if flag set',
-  async t => {
-    const { release, stubs } = setup()
-    await release({
-      ...DEFAULT_ACTION_DATA,
-      inputs: {
-        'app-name': APP_NAME,
-        'npm-token': 'a-token',
-        access: 'restricted',
-      },
-    })
+  sinon.assert.notCalled(stubs.coreStub.setFailed)
+  t.pass('did not set failed')
 
-    sinon.assert.notCalled(stubs.coreStub.setFailed)
-    t.pass('did not set failed')
+  sinon.assert.calledWithMatch(stubs.publishToNpmStub, {
+    npmToken: 'a-token',
+    opticUrl: 'https://optic-test.run.app/api/generate/',
+    npmTag: 'latest',
+    access: 'public',
+  })
+  t.pass('called publishToNpm')
+})
 
-    sinon.assert.calledWithMatch(stubs.publishToNpmStub, {
-      npmToken: 'a-token',
-      opticUrl: 'https://optic-test.run.app/api/generate/',
-      npmTag: 'latest',
+tap.test('Should publish with --access restricted if flag set', async t => {
+  const { release, stubs } = setup()
+  await release({
+    ...DEFAULT_ACTION_DATA,
+    inputs: {
+      'app-name': APP_NAME,
+      'npm-token': 'a-token',
       access: 'restricted',
-    })
-    t.pass('called publishToNpm')
-  }
-)
+    },
+  })
 
-tap.test(
-  'Should disallow unsupported --access flag',
-  async t => {
-    const { release, stubs } = setup()
+  sinon.assert.notCalled(stubs.coreStub.setFailed)
+  t.pass('did not set failed')
 
-    const invalidString = 'public; node -e "throw new Error(`arbitrary command executed`)"'
+  sinon.assert.calledWithMatch(stubs.publishToNpmStub, {
+    npmToken: 'a-token',
+    opticUrl: 'https://optic-test.run.app/api/generate/',
+    npmTag: 'latest',
+    access: 'restricted',
+  })
+  t.pass('called publishToNpm')
+})
 
-    await release({
-      ...DEFAULT_ACTION_DATA,
-      inputs: {
-        'app-name': APP_NAME,
-        'npm-token': 'a-token',
-        access: invalidString,
-      },
-    })
+tap.test('Should disallow unsupported --access flag', async t => {
+  const { release, stubs } = setup()
 
-    sinon.assert.calledWithMatch(
-      stubs.coreStub.setFailed,
-      `Invalid "access" option provided ("${invalidString}"), should be one of "public", "restricted"`
-    )
-    t.pass('did set failed')
-  }
-)
+  const invalidString =
+    'public; node -e "throw new Error(`arbitrary command executed`)"'
+
+  await release({
+    ...DEFAULT_ACTION_DATA,
+    inputs: {
+      'app-name': APP_NAME,
+      'npm-token': 'a-token',
+      access: invalidString,
+    },
+  })
+
+  sinon.assert.calledWithMatch(
+    stubs.coreStub.setFailed,
+    `Invalid "access" option provided ("${invalidString}"), should be one of "public", "restricted"`
+  )
+  t.pass('did set failed')
+})
 
 tap.test(
   'Should publish with --access public and provenance if unscoped and unpublished',

--- a/test/release.test.js
+++ b/test/release.test.js
@@ -252,7 +252,7 @@ tap.test(
   }
 )
 
-tap.test('Aborts publish with provenance if NPM version too old', async t => {
+tap.test('Aborts publish with provenance if NPM version too old', async () => {
   const { release, stubs } = setup({
     npmVersion: '9.4.0', // too old (is before 9.5.0)
     env: { ACTIONS_ID_TOKEN_REQUEST_URL: 'https://example.com' }, // valid
@@ -271,10 +271,9 @@ tap.test('Aborts publish with provenance if NPM version too old', async t => {
     stubs.coreStub.setFailed,
     'Provenance requires NPM >=9.5.0, but this action is using v9.4.0'
   )
-  t.pass('did set failed')
 })
 
-tap.test('Aborts publish with provenance if missing permission', async t => {
+tap.test('Aborts publish with provenance if missing permission', async () => {
   const { release, stubs } = setup({
     npmVersion: '9.5.0', // valid, but before missing var is correctly handled on NPM's side (9.6.1)
     // missing ACTIONS_ID_TOKEN_REQUEST_URL which is set from `id-token: write` permission.
@@ -293,7 +292,6 @@ tap.test('Aborts publish with provenance if missing permission', async t => {
     stubs.coreStub.setFailed,
     'Provenance generation in GitHub Actions requires "write" access to the "id-token" permission'
   )
-  t.pass('did set failed')
 })
 
 tap.test('Should publish with --access public if flag set', async t => {
@@ -342,7 +340,7 @@ tap.test('Should publish with --access restricted if flag set', async t => {
   t.pass('called publishToNpm')
 })
 
-tap.test('Should disallow unsupported --access flag', async t => {
+tap.test('Should disallow unsupported --access flag', async () => {
   const { release, stubs } = setup()
 
   const invalidString =
@@ -361,7 +359,6 @@ tap.test('Should disallow unsupported --access flag', async t => {
     stubs.coreStub.setFailed,
     `Invalid "access" option provided ("${invalidString}"), should be one of "public", "restricted"`
   )
-  t.pass('did set failed')
 })
 
 tap.test(


### PR DESCRIPTION
closes https://github.com/nearform-actions/optic-release-automation-action/issues/301

This follows on from https://github.com/nearform-actions/optic-release-automation-action/pull/302 (starting a new branch / PR as we're both on personal forks) and does two related things:

- [x] Allows users to manually set the access control of their package in the input options, like `access: public` or `access: restricted`
- [x] Fixes https://github.com/nearform-actions/optic-release-automation-action/issues/301 and allows never-published unscoped packages to be published with provenance in their first release, by inserting `--access: public` if and only if:
   - the user hasn't specified access control in any way, and
   - the package is unscoped (therefore, inherently public and cannot be private / restricted), and
   - the package hasn't been published before (so NPM's provenance feature would fail to see it as public unless we do this)

This would be a **minor version bump** on the action: the access control is a new feature, there's no breaking change or requirement to use the new feature because the provenance fix only has an affect when the package would have been public anyway.

Here's an example of an unscoped package published for the first time with provenance using this, without explicitly (redundantly) specifying the package to be public: https://www.npmjs.com/package/alansl-new-release-tester-2/v/0.1.0

---

@simoneb looks like I can't add you via "assign reviews" so I'll ping you here