### PR TITLE
chore: await async tests, assert exec calls

### DIFF
--- a/test/archiver.test.js
+++ b/test/archiver.test.js
@@ -36,13 +36,13 @@ tap.test('throws an error if path not found', async t => {
     },
   })
 
-  t.rejects(archiverModule.archiveItem('path', 'out.zip'))
+  await t.rejects(archiverModule.archiveItem('path', 'out.zip'))
 })
 
 tap.test('does not throw any errors if directory', async t => {
   const { archiverModule } = setup({ isDirectory: true })
 
-  t.resolves(archiverModule.archiveItem('path', 'out.zip'))
+  await t.resolves(archiverModule.archiveItem('path', 'out.zip'))
 })
 
 tap.test('throws if writing to zip file fails', async t => {
@@ -65,7 +65,7 @@ tap.test('throws if writing to zip file fails', async t => {
     },
   })
 
-  t.rejects(archiverModule.archiveItem('path', 'out.zip'))
+  await t.rejects(archiverModule.archiveItem('path', 'out.zip'))
 })
 
 tap.test('resolves if a path is not a directory', async t => {
@@ -88,11 +88,11 @@ tap.test('resolves if a path is not a directory', async t => {
     },
   })
 
-  t.resolves(archiverModule.archiveItem('path', 'out.zip'))
+  await t.resolves(archiverModule.archiveItem('path', 'out.zip'))
 })
 
 tap.test('does not throw any errors if file', async t => {
   const { archiverModule } = setup({ isDirectory: false })
 
-  t.resolves(archiverModule.archiveItem('file.js', 'out.zip'))
+  await t.resolves(archiverModule.archiveItem('file.js', 'out.zip'))
 })

--- a/test/artifact.test.js
+++ b/test/artifact.test.js
@@ -54,7 +54,9 @@ tap.test(
 
     const { artifactPath, releaseId, token } = DEFAULT_INPUT_DATA
 
-    t.resolves(attachArtifactModule.attach(artifactPath, releaseId, token))
+    await t.resolves(
+      attachArtifactModule.attach(artifactPath, releaseId, token)
+    )
   }
 )
 
@@ -65,7 +67,7 @@ tap.test(
 
     const { artifactPath, releaseId, token } = DEFAULT_INPUT_DATA
 
-    t.resolves(
+    await t.resolves(
       attachArtifactModule.attach(
         artifactPath + ZIP_EXTENSION,
         releaseId,
@@ -88,7 +90,7 @@ tap.test(
 
     const { artifactPath, releaseId, token } = DEFAULT_INPUT_DATA
 
-    t.rejects(artifactModule.attach(artifactPath, releaseId, token))
+    await t.rejects(artifactModule.attach(artifactPath, releaseId, token))
   }
 )
 
@@ -99,7 +101,7 @@ tap.test(
 
     const { artifactPath, releaseId, token } = DEFAULT_INPUT_DATA
 
-    t.rejects(attachArtifactModule.attach(artifactPath, releaseId, token))
+    await t.rejects(attachArtifactModule.attach(artifactPath, releaseId, token))
   }
 )
 
@@ -137,6 +139,6 @@ tap.test(
 
     const { artifactPath, releaseId, token } = DEFAULT_INPUT_DATA
 
-    t.rejects(artifactModule.attach(artifactPath, releaseId, token))
+    await t.rejects(artifactModule.attach(artifactPath, releaseId, token))
   }
 )

--- a/test/execWithOutput.test.js
+++ b/test/execWithOutput.test.js
@@ -32,8 +32,8 @@ tap.test(
       return Promise.resolve(0)
     })
 
-    execStub.calledWith('ls', ['-al'])
     await t.resolves(execWithOutputModule.execWithOutput('ls', ['-al']), output)
+    sinon.assert.calledWithExactly(execStub, 'ls', ['-al'], sinon.match({}))
   }
 )
 
@@ -52,7 +52,7 @@ tap.test(
       'Error: ls -al returned code 1  \nSTDOUT:  \nSTDERR: ${output}'
     )
 
-    execStub.calledWith('ls', ['-al'])
+    sinon.assert.calledWithExactly(execStub, 'ls', ['-al'], sinon.match({}))
   }
 )
 
@@ -60,8 +60,8 @@ tap.test('provides cwd to exec function', async () => {
   const cwd = './'
 
   execStub.resolves(0)
-  execStub.calledWith('command', [], { cwd })
   await execWithOutputModule.execWithOutput('command', [], { cwd })
+  sinon.assert.calledWithExactly(execStub, 'command', [], sinon.match({ cwd }))
 })
 
 tap.test('rejects if exit code is not 0', async t => {
@@ -73,8 +73,8 @@ tap.test('rejects if exit code is not 0', async t => {
     return Promise.resolve(1)
   })
 
-  execStub.calledWith('command')
   await t.rejects(execWithOutputModule.execWithOutput('command'))
+  sinon.assert.calledWith(execStub, 'command', [], sinon.match({}))
 })
 
 tap.test('passes env vars excluding `INPUT_*` env vars', async t => {

--- a/test/execWithOutput.test.js
+++ b/test/execWithOutput.test.js
@@ -32,8 +32,8 @@ tap.test(
       return Promise.resolve(0)
     })
 
-    t.resolves(execWithOutputModule.execWithOutput('ls', ['-al']), output)
     execStub.calledWith('ls', ['-al'])
+    await t.resolves(execWithOutputModule.execWithOutput('ls', ['-al']), output)
   }
 )
 
@@ -47,7 +47,7 @@ tap.test(
       return Promise.reject(new Error())
     })
 
-    t.rejects(
+    await t.rejects(
       () => execWithOutputModule.execWithOutput('ls', ['-al']),
       'Error: ls -al returned code 1  \nSTDOUT:  \nSTDERR: ${output}'
     )
@@ -60,8 +60,8 @@ tap.test('provides cwd to exec function', async () => {
   const cwd = './'
 
   execStub.resolves(0)
-  execWithOutputModule.execWithOutput('command', [], cwd)
   execStub.calledWith('command', [], { cwd })
+  await execWithOutputModule.execWithOutput('command', [], { cwd })
 })
 
 tap.test('rejects if exit code is not 0', async t => {
@@ -73,8 +73,8 @@ tap.test('rejects if exit code is not 0', async t => {
     return Promise.resolve(1)
   })
 
-  t.rejects(execWithOutputModule.execWithOutput('command'))
   execStub.calledWith('command')
+  await t.rejects(execWithOutputModule.execWithOutput('command'))
 })
 
 tap.test('passes env vars excluding `INPUT_*` env vars', async t => {

--- a/test/execWithOutput.test.js
+++ b/test/execWithOutput.test.js
@@ -74,7 +74,7 @@ tap.test('rejects if exit code is not 0', async t => {
   })
 
   await t.rejects(execWithOutputModule.execWithOutput('command'))
-  sinon.assert.calledWith(execStub, 'command', [], sinon.match({}))
+  sinon.assert.calledWithExactly(execStub, 'command', [], sinon.match({}))
 })
 
 tap.test('passes env vars excluding `INPUT_*` env vars', async t => {

--- a/test/notifyIssues.test.js
+++ b/test/notifyIssues.test.js
@@ -293,7 +293,7 @@ tap.test("Shouldn't fail if createComment on an issue fails", async t => {
 
   createCommentStub.rejects()
 
-  t.resolves(
+  await t.resolves(
     notifyIssues(
       { ...DEFAULT_GITHUB_CLIENT, graphql: graphqlStub },
       true,

--- a/test/release.test.js
+++ b/test/release.test.js
@@ -911,7 +911,7 @@ tap.test('Should not reject when notifyIssues fails', async t => {
 
   stubs.notifyIssuesStub.rejects()
 
-  t.resolves(
+  await t.resolves(
     release({
       ...DEFAULT_ACTION_DATA,
       inputs: {


### PR DESCRIPTION
This came up in review of https://github.com/nearform-actions/optic-release-automation-action/pull/305 (specifically [this comment thread](https://github.com/nearform-actions/optic-release-automation-action/pull/305#discussion_r1203712994))

> when you make async assertions (such as .rejects or .resolves), you need to either return or (preferably, in my opinion) await the result of the assertion, otherwise the assertion will be a noop

- [x] As discussed, there were a lot of pre-existing non-await `t.resolves` and `t.rejects` in tests, so this tidies them up.
- [x] There were also some `stub.calledWith()` calls that look like they were supposed to be test assertions, but didn't actually assert anything, they just returned `true` or `false` into the void. I've replaced these with actual assertions.