### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npm run update-readme-TOC
 git add README.md
 npm run build && git add dist

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint .",
     "test": "tap",
     "build": "ncc build src/index.js",
-    "prepare": "husky install",
+    "prepare": "husky",
     "update-readme-TOC": "doctoc README.md"
   },
   "keywords": [],


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)