### PR TITLE
fix(517): handle optic and ngrok promise race

### DIFF
--- a/src/utils/ngrokOtpVerification.js
+++ b/src/utils/ngrokOtpVerification.js
@@ -19,7 +19,8 @@ async function ngrokOtpVerification(packageInfo, ngrokToken, abortSignal) {
   })
 
   const timeout = setTimeout(() => {
-    otpPromiseReject('OTP submission timed out.')
+    logError('OTP submission timed out.')
+    otpPromiseReject()
   }, otpVerificationTimeout)
 
   abortSignal?.addEventListener('abort', () => {

--- a/src/utils/publishToNpm.js
+++ b/src/utils/publishToNpm.js
@@ -69,6 +69,7 @@ async function publishToNpm({
     if (opticToken || ngrokToken) {
       try {
         const otpPromises = []
+        const abortCtrl = new AbortController()
 
         if (opticToken) {
           otpPromises.push(
@@ -94,11 +95,13 @@ async function publishToNpm({
                 version,
                 name: localInfo?.name,
               },
-              ngrokToken
+              ngrokToken,
+              abortCtrl.signal
             )
           )
         }
         const otp = await Promise.race(otpPromises)
+        abortCtrl.abort()
         await execWithOutput('npm', ['publish', '--otp', otp, ...flags])
       } catch (error) {
         throw new Error(`OTP verification failed: ${error.message}`)

--- a/test/ngrokOtpVerification.test.js
+++ b/test/ngrokOtpVerification.test.js
@@ -106,7 +106,7 @@ describe('ngrok otp tests', async () => {
     }
   })
 
-  it('Should not timeout when the abort is triggered before the 5 minutes end', async () => {
+  it('Should reject right away when abort is triggered and not log the timeout error', async () => {
     const { ngrokOtpVerificationProxy, logErrorStub } = setup()
 
     const clock = sinon.useFakeTimers()

--- a/test/ngrokOtpVerification.test.js
+++ b/test/ngrokOtpVerification.test.js
@@ -84,7 +84,7 @@ describe('ngrok otp tests', async () => {
   })
 
   it('Should timeout after 5 minutes', async () => {
-    const { ngrokOtpVerificationProxy } = setup()
+    const { ngrokOtpVerificationProxy, logErrorStub } = setup()
 
     const clock = sinon.useFakeTimers()
 
@@ -100,11 +100,7 @@ describe('ngrok otp tests', async () => {
       clock.tick(300001)
 
       await assert.rejects(promise)
-      assert.equal(
-        await promise.catch(reason => reason),
-        'OTP submission timed out.',
-        'should reject with the expected message'
-      )
+      assert.ok(logErrorStub.calledWith('OTP submission timed out.'))
     } finally {
       clock.restore()
     }

--- a/test/ngrokOtpVerification.test.js
+++ b/test/ngrokOtpVerification.test.js
@@ -84,7 +84,7 @@ describe('ngrok otp tests', async () => {
   })
 
   it('Should timeout after 5 minutes', async () => {
-    const { ngrokOtpVerificationProxy, logErrorStub } = setup()
+    const { ngrokOtpVerificationProxy } = setup()
 
     const clock = sinon.useFakeTimers()
 
@@ -100,7 +100,11 @@ describe('ngrok otp tests', async () => {
       clock.tick(300001)
 
       await assert.rejects(promise)
-      assert.ok(logErrorStub.calledWith('OTP submission timed out.'))
+      assert.equal(
+        await promise.catch(reason => reason),
+        'OTP submission timed out.',
+        'should reject with the expected message'
+      )
     } finally {
       clock.restore()
     }

--- a/test/ngrokOtpVerification.test.js
+++ b/test/ngrokOtpVerification.test.js
@@ -106,6 +106,32 @@ describe('ngrok otp tests', async () => {
     }
   })
 
+  it('Should not timeout when the abort is triggered before the 5 minutes end', async () => {
+    const { ngrokOtpVerificationProxy, logErrorStub } = setup()
+
+    const clock = sinon.useFakeTimers()
+
+    const abortCtrl = new AbortController()
+    try {
+      const promise = ngrokOtpVerificationProxy(
+        {
+          name: 'test-package',
+          version: 'v1.0.0',
+        },
+        'ngrok-token',
+        abortCtrl.signal
+      )
+
+      clock.tick(150000)
+      abortCtrl.abort()
+      await assert.rejects(promise)
+      assert.ok(logErrorStub.notCalled)
+      assert.equal(await promise.catch(e => e), 'Aborted')
+    } finally {
+      clock.restore()
+    }
+  })
+
   it('Should handle HTML template rendering', async () => {
     const { ngrokOtpVerificationProxy, mockApp } = setup()
 

--- a/test/publishToNpm.test.js
+++ b/test/publishToNpm.test.js
@@ -385,10 +385,12 @@ describe('publishToNpm tests', async () => {
       version: 'v5.1.3',
     })
 
+    const ctrl = new AbortController()
     sinon.assert.calledWithExactly(
       otpVerificationStub,
       { version: 'v5.1.3', name: 'fakeTestPkg' },
-      'ngrok-token'
+      'ngrok-token',
+      ctrl.signal
     )
 
     sinon.assert.calledWithExactly(execWithOutputStub, 'npm', [


### PR DESCRIPTION
fixes #517 
- adds an abort signal to reject ngrok promise when any otp promise settles which will close the fastify server that keeps the action running more time than needed and also supresses the timeout error log message