### PR TITLE
fix: error message matching

### DIFF
--- a/src/utils/releases.js
+++ b/src/utils/releases.js
@@ -20,7 +20,9 @@ async function fetchLatestRelease(token) {
 
     return latestRelease
   } catch (err) {
-    if (err.message === 'Not Found') {
+    if (err?.message?.includes('Not Found')) {
+      // This is mostly likely to happen when there are no previous releases for the repository yet, i.e v1.0.0 etc.
+      // In this case, it's not necessarily an error, so we just return and proceed with the release
       logInfo(`No previous releases found`)
       return
     }
@@ -72,7 +74,7 @@ async function fetchReleaseByTag(token, tag) {
 
     return release
   } catch (err) {
-    if (err.message === 'Not Found') {
+    if (err?.message?.includes('Not Found')) {
       logError(`Release with tag ${tag} not found.`)
       throw err
     }


### PR DESCRIPTION
It appears that the error message from this is not longer just "Not Found" and thus our hard equality check fails. The message still includes "Not Found", so we can just check for that instead. The full error is now something like: `Not Found - https://docs.github.com/rest/releases/releases#get-the-latest-release`

Fixes #555 