### PR TITLE
fix: Fix quoting of npm install for oidc publishing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -111,7 +111,7 @@ runs:
     - name: Upgrade npm for OIDC publishing
       if: ${{ inputs.publish-mode == 'oidc' }}
       run: |
-        npm install -g npm@>=11.5.1
+        npm install -g "npm@>=11.5.1"
       shell: bash
 
     - name: Install ngrok


### PR DESCRIPTION
Running this action with `publish-mode: oidc` results in the creation of a file `=11.5.1`, due to the lack of quotes in the command `npm install -g npm@>=11.5.1` which runs when publish mode is `oidc`. Fixes #589 